### PR TITLE
DT-1591: Refactor MailMessage createModel

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DACMembersDARRADARApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DACMembersDARRADARApprovedMessage.java
@@ -34,13 +34,18 @@ public class DACMembersDARRADARApprovedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "userName", toUser.getDisplayName(),
-        "darCode", darCode,
-        "researcherUserName", researcher.getDisplayName(),
-        "datasets", datasets,
-        "serverUrl", serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "userName",
+            toUser.getDisplayName(),
+            "darCode",
+            darCode,
+            "researcherUserName",
+            researcher.getDisplayName(),
+            "datasets",
+            datasets));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DACMembersDARRADARApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DACMembersDARRADARApprovedMessage.java
@@ -34,18 +34,16 @@ public class DACMembersDARRADARApprovedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "userName",
-            toUser.getDisplayName(),
-            "darCode",
-            darCode,
-            "researcherUserName",
-            researcher.getDisplayName(),
-            "datasets",
-            datasets));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "userName",
+        toUser.getDisplayName(),
+        "darCode",
+        darCode,
+        "researcherUserName",
+        researcher.getDisplayName(),
+        "datasets",
+        datasets);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
@@ -30,7 +30,7 @@ public class DacVoteDigestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
+  public Map<String, Object> createModel() {
     List<Reminder> sortedReminderList =
         userReminderList.stream()
             .filter(r -> r.createDate() != null)
@@ -39,17 +39,15 @@ public class DacVoteDigestMessage extends MailMessage {
     List<Reminder> currentWeekReminders = getCurrentWeekReminders(sortedReminderList);
     List<Reminder> lastWeekReminders = getLastWeekReminders(sortedReminderList);
     List<Reminder> olderReminders = getOlderReminders(sortedReminderList);
-    return mergeModel(
-        model,
-        Map.of(
-            "userName",
-            toUser.getDisplayName(),
-            "openedThisWeek",
-            currentWeekReminders,
-            "openedLastWeek",
-            lastWeekReminders,
-            "olderRequests",
-            olderReminders));
+    return Map.of(
+        "userName",
+        toUser.getDisplayName(),
+        "openedThisWeek",
+        currentWeekReminders,
+        "openedLastWeek",
+        lastWeekReminders,
+        "olderRequests",
+        olderReminders);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
@@ -30,7 +30,7 @@ public class DacVoteDigestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
+  public Object createModel(Map<String, Object> model) {
     List<Reminder> sortedReminderList =
         userReminderList.stream()
             .filter(r -> r.createDate() != null)
@@ -39,12 +39,17 @@ public class DacVoteDigestMessage extends MailMessage {
     List<Reminder> currentWeekReminders = getCurrentWeekReminders(sortedReminderList);
     List<Reminder> lastWeekReminders = getLastWeekReminders(sortedReminderList);
     List<Reminder> olderReminders = getOlderReminders(sortedReminderList);
-    return Map.of(
-        "userName", toUser.getDisplayName(),
-        "openedThisWeek", currentWeekReminders,
-        "openedLastWeek", lastWeekReminders,
-        "olderRequests", olderReminders,
-        "serverUrl", serverUrl);
+    return mergeModel(
+        model,
+        Map.of(
+            "userName",
+            toUser.getDisplayName(),
+            "openedThisWeek",
+            currentWeekReminders,
+            "openedLastWeek",
+            lastWeekReminders,
+            "olderRequests",
+            olderReminders));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DarExpirationReminderMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DarExpirationReminderMessage.java
@@ -21,8 +21,8 @@ public class DarExpirationReminderMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of("userName", toUser.getDisplayName(), "darCode", darCode, "serverUrl", serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(model, Map.of("userName", toUser.getDisplayName(), "darCode", darCode));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DarExpirationReminderMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DarExpirationReminderMessage.java
@@ -21,8 +21,8 @@ public class DarExpirationReminderMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(model, Map.of("userName", toUser.getDisplayName(), "darCode", darCode));
+  public Map<String, Object> createModel() {
+    return Map.of("userName", toUser.getDisplayName(), "darCode", darCode);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DarExpiredMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DarExpiredMessage.java
@@ -21,8 +21,8 @@ public class DarExpiredMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(model, Map.of("researcherName", toUser.getDisplayName(), "darCode", darCode));
+  public Map<String, Object> createModel() {
+    return Map.of("researcherName", toUser.getDisplayName(), "darCode", darCode);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DarExpiredMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DarExpiredMessage.java
@@ -21,8 +21,8 @@ public class DarExpiredMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of("researcherName", toUser.getDisplayName(), "darCode", darCode);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(model, Map.of("researcherName", toUser.getDisplayName(), "darCode", darCode));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
@@ -35,18 +35,20 @@ public class DataCustodianApprovalMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "datasets",
-        datasets,
-        "dataDepositorName",
-        dataDepositorName,
-        "darCode",
-        darCode,
-        "researcherEmail",
-        researcherEmail,
-        "radarText",
-        radarText);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "datasets",
+            datasets,
+            "dataDepositorName",
+            dataDepositorName,
+            "darCode",
+            darCode,
+            "researcherEmail",
+            researcherEmail,
+            "radarText",
+            radarText));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
@@ -35,20 +35,18 @@ public class DataCustodianApprovalMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "datasets",
-            datasets,
-            "dataDepositorName",
-            dataDepositorName,
-            "darCode",
-            darCode,
-            "researcherEmail",
-            researcherEmail,
-            "radarText",
-            radarText));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "datasets",
+        datasets,
+        "dataDepositorName",
+        dataDepositorName,
+        "darCode",
+        darCode,
+        "researcherEmail",
+        researcherEmail,
+        "radarText",
+        radarText);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetApprovedMessage.java
@@ -25,18 +25,16 @@ public class DatasetApprovedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "dataSubmitterName",
-            toUser.getDisplayName(),
-            "datasetIdentifier",
-            datasetIdentifier,
-            "datasetName",
-            datasetName,
-            "dacName",
-            dacName));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "dataSubmitterName",
+        toUser.getDisplayName(),
+        "datasetIdentifier",
+        datasetIdentifier,
+        "datasetName",
+        datasetName,
+        "dacName",
+        dacName);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetApprovedMessage.java
@@ -25,18 +25,18 @@ public class DatasetApprovedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "serverUrl",
-        serverUrl,
-        "dataSubmitterName",
-        toUser.getDisplayName(),
-        "datasetIdentifier",
-        datasetIdentifier,
-        "datasetName",
-        datasetName,
-        "dacName",
-        dacName);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "dataSubmitterName",
+            toUser.getDisplayName(),
+            "datasetIdentifier",
+            datasetIdentifier,
+            "datasetName",
+            datasetName,
+            "dacName",
+            dacName));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetDeniedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetDeniedMessage.java
@@ -25,18 +25,16 @@ public class DatasetDeniedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "dataSubmitterName",
-            toUser.getDisplayName(),
-            "datasetName",
-            datasetName,
-            "dacName",
-            dacName,
-            "dacEmail",
-            dacEmail));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "dataSubmitterName",
+        toUser.getDisplayName(),
+        "datasetName",
+        datasetName,
+        "dacName",
+        dacName,
+        "dacEmail",
+        dacEmail);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetDeniedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetDeniedMessage.java
@@ -25,16 +25,18 @@ public class DatasetDeniedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "dataSubmitterName",
-        toUser.getDisplayName(),
-        "datasetName",
-        datasetName,
-        "dacName",
-        dacName,
-        "dacEmail",
-        dacEmail);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "dataSubmitterName",
+            toUser.getDisplayName(),
+            "datasetName",
+            datasetName,
+            "dacName",
+            dacName,
+            "dacEmail",
+            dacEmail));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetSubmittedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetSubmittedMessage.java
@@ -27,18 +27,16 @@ public class DatasetSubmittedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "dacChairName",
-            toUser.getDisplayName(),
-            "dataSubmitterName",
-            dataSubmitterName,
-            "datasetName",
-            datasetName,
-            "dacName",
-            dacName));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "dacChairName",
+        toUser.getDisplayName(),
+        "dataSubmitterName",
+        dataSubmitterName,
+        "datasetName",
+        datasetName,
+        "dacName",
+        dacName);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetSubmittedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DatasetSubmittedMessage.java
@@ -27,16 +27,18 @@ public class DatasetSubmittedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "dacChairName",
-        toUser.getDisplayName(),
-        "dataSubmitterName",
-        dataSubmitterName,
-        "datasetName",
-        datasetName,
-        "dacName",
-        dacName);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "dacChairName",
+            toUser.getDisplayName(),
+            "dataSubmitterName",
+            dataSubmitterName,
+            "datasetName",
+            datasetName,
+            "dacName",
+            dacName));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.consent.http.mail.message;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import org.broadinstitute.consent.http.enumeration.EmailType;
 import org.broadinstitute.consent.http.models.User;
 
@@ -19,7 +22,25 @@ public abstract class MailMessage {
 
   public abstract String createSubject();
 
-  public abstract Object createModel(String serverUrl);
+  public final Object createModel(String serverUrl) {
+    return createModel(Map.of("serverUrl", serverUrl));
+  }
+
+  public abstract Object createModel(Map<String, Object> model);
+
+  protected final Map<String, Object> mergeModel(
+      Map<String, Object> model, Map<String, Object> additionalModel) {
+    Map<String, Object> mergedModel = new HashMap<>();
+    if (model != null) {
+      mergedModel.putAll(model);
+    }
+    mergedModel.putAll(additionalModel);
+    return mergedModel;
+  }
+
+  protected final String requireServerUrl(Map<String, Object> model) {
+    return Objects.requireNonNull(model.get("serverUrl"), () -> "serverUrl is required").toString();
+  }
 
   public abstract String getEntityReferenceId();
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.mail.message;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import org.broadinstitute.consent.http.enumeration.EmailType;
 import org.broadinstitute.consent.http.models.User;
 
@@ -22,25 +21,13 @@ public abstract class MailMessage {
 
   public abstract String createSubject();
 
-  public final Object createModel(String serverUrl) {
-    return createModel(Map.of("serverUrl", serverUrl));
+  public final Map<String, Object> createModel(String serverUrl) {
+    Map<String, Object> model = new HashMap<>(createModel());
+    model.putIfAbsent("serverUrl", serverUrl);
+    return model;
   }
 
-  public abstract Object createModel(Map<String, Object> model);
-
-  protected final Map<String, Object> mergeModel(
-      Map<String, Object> model, Map<String, Object> additionalModel) {
-    Map<String, Object> mergedModel = new HashMap<>();
-    if (model != null) {
-      mergedModel.putAll(model);
-    }
-    mergedModel.putAll(additionalModel);
-    return mergedModel;
-  }
-
-  protected final String requireServerUrl(Map<String, Object> model) {
-    return Objects.requireNonNull(model.get("serverUrl"), () -> "serverUrl is required").toString();
-  }
+  public abstract Map<String, Object> createModel();
 
   public abstract String getEntityReferenceId();
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
@@ -27,16 +27,11 @@ public class NewCaseMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "userName",
-        toUser.getDisplayName(),
-        "electionType",
-        type,
-        "entityName",
-        referenceId,
-        "serverUrl",
-        serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "userName", toUser.getDisplayName(), "electionType", type, "entityName", referenceId));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
@@ -27,11 +27,9 @@ public class NewCaseMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "userName", toUser.getDisplayName(), "electionType", type, "entityName", referenceId));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "userName", toUser.getDisplayName(), "electionType", type, "entityName", referenceId);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadResearcherMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadResearcherMessage.java
@@ -26,18 +26,16 @@ public class NewDAAUploadResearcherMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "dacName",
-            dacName,
-            "researcherUserName",
-            toUser.getDisplayName(),
-            "previousDaaName",
-            previousDaaName,
-            "newDaaName",
-            newDaaName));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "dacName",
+        dacName,
+        "researcherUserName",
+        toUser.getDisplayName(),
+        "previousDaaName",
+        previousDaaName,
+        "newDaaName",
+        newDaaName);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadResearcherMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadResearcherMessage.java
@@ -26,18 +26,18 @@ public class NewDAAUploadResearcherMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "serverUrl",
-        serverUrl,
-        "dacName",
-        dacName,
-        "researcherUserName",
-        toUser.getDisplayName(),
-        "previousDaaName",
-        previousDaaName,
-        "newDaaName",
-        newDaaName);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "dacName",
+            dacName,
+            "researcherUserName",
+            toUser.getDisplayName(),
+            "previousDaaName",
+            previousDaaName,
+            "newDaaName",
+            newDaaName));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadSOMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadSOMessage.java
@@ -25,18 +25,16 @@ public class NewDAAUploadSOMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "dacName",
-            dacName,
-            "signingOfficialUserName",
-            toUser.getDisplayName(),
-            "previousDaaName",
-            previousDaaName,
-            "newDaaName",
-            newDaaName));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "dacName",
+        dacName,
+        "signingOfficialUserName",
+        toUser.getDisplayName(),
+        "previousDaaName",
+        previousDaaName,
+        "newDaaName",
+        newDaaName);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadSOMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadSOMessage.java
@@ -25,18 +25,18 @@ public class NewDAAUploadSOMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "serverUrl",
-        serverUrl,
-        "dacName",
-        dacName,
-        "signingOfficialUserName",
-        toUser.getDisplayName(),
-        "previousDaaName",
-        previousDaaName,
-        "newDaaName",
-        newDaaName);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "dacName",
+            dacName,
+            "signingOfficialUserName",
+            toUser.getDisplayName(),
+            "previousDaaName",
+            previousDaaName,
+            "newDaaName",
+            newDaaName));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
@@ -29,13 +29,18 @@ public class NewDARRequestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "serverUrl", serverUrl,
-        "userName", toUser.getDisplayName(),
-        "dacDatasetGroups", dacDatasetMap,
-        "researcherUserName", researcherName,
-        "darID", darCode);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "userName",
+            toUser.getDisplayName(),
+            "dacDatasetGroups",
+            dacDatasetMap,
+            "researcherUserName",
+            researcherName,
+            "darID",
+            darCode));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
@@ -29,18 +29,16 @@ public class NewDARRequestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "userName",
-            toUser.getDisplayName(),
-            "dacDatasetGroups",
-            dacDatasetMap,
-            "researcherUserName",
-            researcherName,
-            "darID",
-            darCode));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "userName",
+        toUser.getDisplayName(),
+        "dacDatasetGroups",
+        dacDatasetMap,
+        "researcherUserName",
+        researcherName,
+        "darID",
+        darCode);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARSigningOfficialRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARSigningOfficialRequestMessage.java
@@ -24,16 +24,14 @@ public class NewDARSigningOfficialRequestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "userName",
-            toUser.getDisplayName(),
-            "researcherUserName",
-            researcherName,
-            "darID",
-            darCode));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "userName",
+        toUser.getDisplayName(),
+        "researcherUserName",
+        researcherName,
+        "darID",
+        darCode);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARSigningOfficialRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARSigningOfficialRequestMessage.java
@@ -24,12 +24,16 @@ public class NewDARSigningOfficialRequestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "serverUrl", serverUrl,
-        "userName", toUser.getDisplayName(),
-        "researcherUserName", researcherName,
-        "darID", darCode);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "userName",
+            toUser.getDisplayName(),
+            "researcherUserName",
+            researcherName,
+            "darID",
+            darCode));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessage.java
@@ -17,8 +17,14 @@ public class NewLibraryCardIssuedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of("linkUrl", serverUrl + "datalibrary", "displayName", toUser.getDisplayName());
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "linkUrl",
+            requireServerUrl(model) + "datalibrary",
+            "displayName",
+            toUser.getDisplayName()));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessage.java
@@ -17,14 +17,8 @@ public class NewLibraryCardIssuedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "linkUrl",
-            requireServerUrl(model) + "datalibrary",
-            "displayName",
-            toUser.getDisplayName()));
+  public Map<String, Object> createModel() {
+    return Map.of("displayName", toUser.getDisplayName());
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportCaseMessage.java
@@ -20,9 +20,9 @@ public class NewProgressReportCaseMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "userName", toUser.getDisplayName(), "entityName", referenceId, "serverUrl", serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model, Map.of("userName", toUser.getDisplayName(), "entityName", referenceId));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportCaseMessage.java
@@ -20,9 +20,8 @@ public class NewProgressReportCaseMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model, Map.of("userName", toUser.getDisplayName(), "entityName", referenceId));
+  public Map<String, Object> createModel() {
+    return Map.of("userName", toUser.getDisplayName(), "entityName", referenceId);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessage.java
@@ -35,18 +35,16 @@ public class NewProgressReportRequestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "userName",
-            toUser.getDisplayName(),
-            "dacDatasetGroups",
-            dacDatasetMap,
-            "researcherUserName",
-            researcherName,
-            "darID",
-            darCode));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "userName",
+        toUser.getDisplayName(),
+        "dacDatasetGroups",
+        dacDatasetMap,
+        "researcherUserName",
+        researcherName,
+        "darID",
+        darCode);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessage.java
@@ -35,13 +35,18 @@ public class NewProgressReportRequestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "serverUrl", serverUrl,
-        "userName", toUser.getDisplayName(),
-        "dacDatasetGroups", dacDatasetMap,
-        "researcherUserName", researcherName,
-        "darID", darCode);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "userName",
+            toUser.getDisplayName(),
+            "dacDatasetGroups",
+            dacDatasetMap,
+            "researcherUserName",
+            researcherName,
+            "darID",
+            darCode));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessage.java
@@ -49,7 +49,6 @@ public class NewProgressReportRequestMessage extends MailMessage {
 
   @Override
   public String getEntityReferenceId() {
-    //
     return referenceId;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessage.java
@@ -24,9 +24,8 @@ public class NewStudyDigestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model, Map.of("userName", toUser.getDisplayName(), "newStudies", newStudiesList));
+  public Map<String, Object> createModel() {
+    return Map.of("userName", toUser.getDisplayName(), "newStudies", newStudiesList);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessage.java
@@ -24,9 +24,9 @@ public class NewStudyDigestMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "userName", toUser.getDisplayName(), "newStudies", newStudiesList, "serverUrl", serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model, Map.of("userName", toUser.getDisplayName(), "newStudies", newStudiesList));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewStudyRegistrationConfirmationMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewStudyRegistrationConfirmationMessage.java
@@ -27,18 +27,16 @@ public class NewStudyRegistrationConfirmationMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "studySubmitterName",
-            toUser.getDisplayName(),
-            "studyName",
-            studyName,
-            "studyId",
-            studyId,
-            "studyAssets",
-            studyAssets));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "studySubmitterName",
+        toUser.getDisplayName(),
+        "studyName",
+        studyName,
+        "studyId",
+        studyId,
+        "studyAssets",
+        studyAssets);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewStudyRegistrationConfirmationMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewStudyRegistrationConfirmationMessage.java
@@ -27,16 +27,18 @@ public class NewStudyRegistrationConfirmationMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "studySubmitterName",
-        toUser.getDisplayName(),
-        "studyName",
-        studyName,
-        "studyId",
-        studyId,
-        "studyAssets",
-        studyAssets);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "studySubmitterName",
+            toUser.getDisplayName(),
+            "studyName",
+            studyName,
+            "studyId",
+            studyId,
+            "studyAssets",
+            studyAssets));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
@@ -40,10 +40,8 @@ public class ReminderMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of("userName", toUser.getDisplayName(), "entityName", darCode, "serverUrl", voteUrl));
+  public Map<String, Object> createModel() {
+    return Map.of("userName", toUser.getDisplayName(), "entityName", darCode, "serverUrl", voteUrl);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
@@ -40,8 +40,10 @@ public class ReminderMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of("userName", toUser.getDisplayName(), "entityName", darCode, "serverUrl", voteUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of("userName", toUser.getDisplayName(), "entityName", darCode, "serverUrl", voteUrl));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedProgressReportMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedProgressReportMessage.java
@@ -34,22 +34,20 @@ public class ResearcherApprovedProgressReportMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "researcherName",
-            toUser.getDisplayName(),
-            "darCode",
-            darCode,
-            "datasets",
-            datasets,
-            "dataUseRestriction",
-            dataUseRestriction,
-            "radarText",
-            radarText,
-            "researcherEmail",
-            toUser.getEmail()));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "researcherName",
+        toUser.getDisplayName(),
+        "darCode",
+        darCode,
+        "datasets",
+        datasets,
+        "dataUseRestriction",
+        dataUseRestriction,
+        "radarText",
+        radarText,
+        "researcherEmail",
+        toUser.getEmail());
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedProgressReportMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedProgressReportMessage.java
@@ -34,20 +34,22 @@ public class ResearcherApprovedProgressReportMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "researcherName",
-        toUser.getDisplayName(),
-        "darCode",
-        darCode,
-        "datasets",
-        datasets,
-        "dataUseRestriction",
-        dataUseRestriction,
-        "radarText",
-        radarText,
-        "researcherEmail",
-        toUser.getEmail());
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "researcherName",
+            toUser.getDisplayName(),
+            "darCode",
+            darCode,
+            "datasets",
+            datasets,
+            "dataUseRestriction",
+            dataUseRestriction,
+            "radarText",
+            radarText,
+            "researcherEmail",
+            toUser.getEmail()));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherCloseoutCompletedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherCloseoutCompletedMessage.java
@@ -21,8 +21,8 @@ public class ResearcherCloseoutCompletedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(model, Map.of("userName", toUser.getDisplayName(), "darCode", darCode));
+  public Map<String, Object> createModel() {
+    return Map.of("userName", toUser.getDisplayName(), "darCode", darCode);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherCloseoutCompletedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherCloseoutCompletedMessage.java
@@ -21,8 +21,8 @@ public class ResearcherCloseoutCompletedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of("userName", toUser.getDisplayName(), "darCode", darCode, "serverUrl", serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(model, Map.of("userName", toUser.getDisplayName(), "darCode", darCode));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherDarApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherDarApprovedMessage.java
@@ -34,22 +34,20 @@ public class ResearcherDarApprovedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "researcherName",
-            toUser.getDisplayName(),
-            "darCode",
-            darCode,
-            "datasets",
-            datasets,
-            "dataUseRestriction",
-            dataUseRestriction,
-            "radarText",
-            radarText,
-            "researcherEmail",
-            toUser.getEmail()));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "researcherName",
+        toUser.getDisplayName(),
+        "darCode",
+        darCode,
+        "datasets",
+        datasets,
+        "dataUseRestriction",
+        dataUseRestriction,
+        "radarText",
+        radarText,
+        "researcherEmail",
+        toUser.getEmail());
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherDarApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherDarApprovedMessage.java
@@ -34,20 +34,22 @@ public class ResearcherDarApprovedMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "researcherName",
-        toUser.getDisplayName(),
-        "darCode",
-        darCode,
-        "datasets",
-        datasets,
-        "dataUseRestriction",
-        dataUseRestriction,
-        "radarText",
-        radarText,
-        "researcherEmail",
-        toUser.getEmail());
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "researcherName",
+            toUser.getDisplayName(),
+            "darCode",
+            darCode,
+            "datasets",
+            datasets,
+            "dataUseRestriction",
+            dataUseRestriction,
+            "radarText",
+            radarText,
+            "researcherEmail",
+            toUser.getEmail()));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SoDARApproved.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SoDARApproved.java
@@ -40,24 +40,22 @@ public class SoDARApproved extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "userName",
-            toUser.getDisplayName(),
-            "darCode",
-            darCode,
-            "radarText",
-            radarText,
-            "researcherUserName",
-            researcher.getDisplayName(),
-            "researcherEmail",
-            researcher.getEmail(),
-            "datasets",
-            datasets,
-            "dataUseRestriction",
-            dataUseRestriction));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "userName",
+        toUser.getDisplayName(),
+        "darCode",
+        darCode,
+        "radarText",
+        radarText,
+        "researcherUserName",
+        researcher.getDisplayName(),
+        "researcherEmail",
+        researcher.getEmail(),
+        "datasets",
+        datasets,
+        "dataUseRestriction",
+        dataUseRestriction);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SoDARApproved.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SoDARApproved.java
@@ -40,24 +40,24 @@ public class SoDARApproved extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "userName",
-        toUser.getDisplayName(),
-        "darCode",
-        darCode,
-        "radarText",
-        radarText,
-        "researcherUserName",
-        researcher.getDisplayName(),
-        "researcherEmail",
-        researcher.getEmail(),
-        "datasets",
-        datasets,
-        "dataUseRestriction",
-        dataUseRestriction,
-        "serverUrl",
-        serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "userName",
+            toUser.getDisplayName(),
+            "darCode",
+            darCode,
+            "radarText",
+            radarText,
+            "researcherUserName",
+            researcher.getDisplayName(),
+            "researcherEmail",
+            researcher.getEmail(),
+            "datasets",
+            datasets,
+            "dataUseRestriction",
+            dataUseRestriction));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SoDARSubmitted.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SoDARSubmitted.java
@@ -30,18 +30,16 @@ public class SoDARSubmitted extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "userName",
-            toUser.getDisplayName(),
-            "darCode",
-            darCode,
-            "researcherUserName",
-            researcher.getDisplayName(),
-            "datasets",
-            datasets));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "userName",
+        toUser.getDisplayName(),
+        "darCode",
+        darCode,
+        "researcherUserName",
+        researcher.getDisplayName(),
+        "datasets",
+        datasets);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SoDARSubmitted.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SoDARSubmitted.java
@@ -30,13 +30,18 @@ public class SoDARSubmitted extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "userName", toUser.getDisplayName(),
-        "darCode", darCode,
-        "researcherUserName", researcher.getDisplayName(),
-        "datasets", datasets,
-        "serverUrl", serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "userName",
+            toUser.getDisplayName(),
+            "darCode",
+            darCode,
+            "researcherUserName",
+            researcher.getDisplayName(),
+            "datasets",
+            datasets));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRApproved.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRApproved.java
@@ -40,24 +40,22 @@ public class SoPRApproved extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "userName",
-            toUser.getDisplayName(),
-            "darCode",
-            darCode,
-            "radarText",
-            radarText,
-            "researcherUserName",
-            researcher.getDisplayName(),
-            "researcherEmail",
-            researcher.getEmail(),
-            "datasets",
-            datasets,
-            "dataUseRestriction",
-            dataUseRestriction));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "userName",
+        toUser.getDisplayName(),
+        "darCode",
+        darCode,
+        "radarText",
+        radarText,
+        "researcherUserName",
+        researcher.getDisplayName(),
+        "researcherEmail",
+        researcher.getEmail(),
+        "datasets",
+        datasets,
+        "dataUseRestriction",
+        dataUseRestriction);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRApproved.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRApproved.java
@@ -40,16 +40,24 @@ public class SoPRApproved extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "userName", toUser.getDisplayName(),
-        "darCode", darCode,
-        "radarText", radarText,
-        "researcherUserName", researcher.getDisplayName(),
-        "researcherEmail", researcher.getEmail(),
-        "datasets", datasets,
-        "dataUseRestriction", dataUseRestriction,
-        "serverUrl", serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "userName",
+            toUser.getDisplayName(),
+            "darCode",
+            darCode,
+            "radarText",
+            radarText,
+            "researcherUserName",
+            researcher.getDisplayName(),
+            "researcherEmail",
+            researcher.getEmail(),
+            "datasets",
+            datasets,
+            "dataUseRestriction",
+            dataUseRestriction));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRSubmitted.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRSubmitted.java
@@ -30,18 +30,16 @@ public class SoPRSubmitted extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of(
-            "userName",
-            toUser.getDisplayName(),
-            "darCode",
-            darCode,
-            "researcherUserName",
-            researcher.getDisplayName(),
-            "datasets",
-            datasets));
+  public Map<String, Object> createModel() {
+    return Map.of(
+        "userName",
+        toUser.getDisplayName(),
+        "darCode",
+        darCode,
+        "researcherUserName",
+        researcher.getDisplayName(),
+        "datasets",
+        datasets);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRSubmitted.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRSubmitted.java
@@ -30,13 +30,18 @@ public class SoPRSubmitted extends MailMessage {
   }
 
   @Override
-  public Object createModel(String serverUrl) {
-    return Map.of(
-        "userName", toUser.getDisplayName(),
-        "darCode", darCode,
-        "researcherUserName", researcher.getDisplayName(),
-        "datasets", datasets,
-        "serverUrl", serverUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of(
+            "userName",
+            toUser.getDisplayName(),
+            "darCode",
+            darCode,
+            "researcherUserName",
+            researcher.getDisplayName(),
+            "datasets",
+            datasets));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SubmittedCloseoutMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SubmittedCloseoutMessage.java
@@ -28,10 +28,8 @@ public class SubmittedCloseoutMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(Map<String, Object> model) {
-    return mergeModel(
-        model,
-        Map.of("displayName", toUser.getDisplayName(), "darId", darId, "linkUrl", closeoutUrl));
+  public Map<String, Object> createModel() {
+    return Map.of("displayName", toUser.getDisplayName(), "darId", darId, "linkUrl", closeoutUrl);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SubmittedCloseoutMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SubmittedCloseoutMessage.java
@@ -28,8 +28,10 @@ public class SubmittedCloseoutMessage extends MailMessage {
   }
 
   @Override
-  public Object createModel(String linkUrl) {
-    return Map.of("displayName", toUser.getDisplayName(), "darId", darId, "linkUrl", closeoutUrl);
+  public Object createModel(Map<String, Object> model) {
+    return mergeModel(
+        model,
+        Map.of("displayName", toUser.getDisplayName(), "darId", darId, "linkUrl", closeoutUrl));
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -18,6 +18,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
@@ -76,7 +77,7 @@ public class EmailService implements ConsentLogger {
       throws IOException, TemplateException {
     Writer out = new StringWriter();
     Template template = templateHelper.getTemplate(mailMessage.getTemplateName());
-    template.process(mailMessage.createModel(serverUrl), out);
+    template.process(mailMessage.createModel(Map.of("serverUrl", serverUrl)), out);
     String content = out.toString();
     Mail message =
         new Mail(

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -18,7 +18,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
@@ -77,7 +76,7 @@ public class EmailService implements ConsentLogger {
       throws IOException, TemplateException {
     Writer out = new StringWriter();
     Template template = templateHelper.getTemplate(mailMessage.getTemplateName());
-    template.process(mailMessage.createModel(Map.of("serverUrl", serverUrl)), out);
+    template.process(mailMessage.createModel(serverUrl), out);
     String content = out.toString();
     Mail message =
         new Mail(

--- a/src/main/resources/freemarker/new-library-card-issued.ftl
+++ b/src/main/resources/freemarker/new-library-card-issued.ftl
@@ -5,7 +5,7 @@
       <td id="content" style="padding: 15px 15px 0; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
         You have successfully been issued a Library Card by your institution’s Signing Official.
         You can now initiate data access requests. Get started by searching for data you would like
-        to access in the DUOS <a href="${linkUrl}"
+        to access in the DUOS <a href="${serverUrl}datalibrary"
           style="text-decoration: none; font-family: 'Montserrat', sans-serif; color: #00609F; font-size: 20px; font-weight: bold;"
       >Data Library</a>.
       </td>

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/AbstractMailMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/AbstractMailMessageTest.java
@@ -1,6 +1,9 @@
 package org.broadinstitute.consent.http.mail.message;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.StringWriter;
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.FreeMarkerConfiguration;
@@ -39,6 +42,15 @@ abstract class AbstractMailMessageTest extends AbstractTestHelper {
     template.process(message.createModel(serverUrl), out);
     var content = out.toString();
     return new RenderedTemplate(content, Jsoup.parse(content));
+  }
+
+  /** Asserts that the message model contains the expected required fields and values. */
+  protected void assertRequiredModelFields(
+      MailMessage message, Map<String, Object> expectedRequiredFields) {
+    Map<String, Object> createdModel = message.createModel();
+    expectedRequiredFields.forEach(
+        (key, value) ->
+            assertEquals(value, createdModel.get(key), "Unexpected model value for " + key));
   }
 
   /** Returns the visible text of the element with the given {@code id}, failing if absent. */

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DACMembersDARRADARApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DACMembersDARRADARApprovedMessageTest.java
@@ -4,11 +4,38 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.junit.jupiter.api.Test;
 
 class DACMembersDARRADARApprovedMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User toUser = new User();
+    toUser.setDisplayName("DAC Member");
+    User researcherUser = new User();
+    researcherUser.setDisplayName("Researcher");
+    List<DatasetMailDTO> datasetMailDTOs =
+        List.of(new DatasetMailDTO("dataset-name", "DUOS-00001", null));
+
+    var message =
+        new DACMembersDARRADARApprovedMessage(
+            toUser, "DAR-0001", researcherUser, "abcd-12345", datasetMailDTOs);
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "userName",
+            "DAC Member",
+            "darCode",
+            "DAR-0001",
+            "researcherUserName",
+            "Researcher",
+            "datasets",
+            datasetMailDTOs));
+  }
 
   @Test
   void testGetDACMembersDARRADARApprovedTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessageTest.java
@@ -9,12 +9,42 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.broadinstitute.consent.http.models.Reminder;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class DacVoteDigestMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User toUser = new User();
+    toUser.setUserId(1);
+    toUser.setDisplayName("Reminder User");
+    Instant timeBasis = Instant.now();
+    Reminder olderReminder =
+        new Reminder(toUser.getUserId(), "DAR-1", 2, timeBasis.minus(21, ChronoUnit.DAYS));
+    Reminder lastWeekReminder =
+        new Reminder(toUser.getUserId(), "DAR-2", 3, timeBasis.minus(7, ChronoUnit.DAYS));
+    Reminder currentWeekReminder =
+        new Reminder(toUser.getUserId(), "DAR-3", 4, timeBasis.minus(1, ChronoUnit.DAYS));
+    List<Reminder> reminderList = List.of(lastWeekReminder, currentWeekReminder, olderReminder);
+
+    var message = new DacVoteDigestMessage(toUser, reminderList, "ref-id", timeBasis);
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "userName",
+            "Reminder User",
+            "openedThisWeek",
+            List.of(currentWeekReminder),
+            "openedLastWeek",
+            List.of(lastWeekReminder),
+            "olderRequests",
+            List.of(olderReminder)));
+  }
 
   @Test
   void testMessageSubject() {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DarExpirationReminderMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DarExpirationReminderMessageTest.java
@@ -2,11 +2,23 @@ package org.broadinstitute.consent.http.mail.message;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Map;
 import java.util.UUID;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class DarExpirationReminderMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User requestUser = new User();
+    requestUser.setDisplayName("Test User");
+
+    var message =
+        new DarExpirationReminderMessage(requestUser, "DAR-123", UUID.randomUUID().toString());
+
+    assertRequiredModelFields(message, Map.of("userName", "Test User", "darCode", "DAR-123"));
+  }
 
   @Test
   void testGetDarExpiredTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DarExpiredMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DarExpiredMessageTest.java
@@ -3,11 +3,22 @@ package org.broadinstitute.consent.http.mail.message;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.UUID;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class DarExpiredMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User requestUser = new User();
+    requestUser.setDisplayName("Test User");
+
+    var message = new DarExpiredMessage(requestUser, "DAR-123", UUID.randomUUID().toString());
+
+    assertRequiredModelFields(message, Map.of("researcherName", "Test User", "darCode", "DAR-123"));
+  }
 
   @Test
   void testGetDarExpiredTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessageTest.java
@@ -5,12 +5,39 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.junit.jupiter.api.Test;
 
 class DataCustodianApprovalMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User toUser = new User();
+    toUser.setDisplayName("Data Custodian");
+    List<DatasetMailDTO> datasetMailDTOs =
+        List.of(new DatasetMailDTO("dataset name", "dataset id", null));
+
+    var message =
+        new DataCustodianApprovalMessage(
+            toUser, "Dar Code", datasetMailDTOs, "Depositor", "researcher@email.com", false);
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "datasets",
+            datasetMailDTOs,
+            "dataDepositorName",
+            "Depositor",
+            "darCode",
+            "Dar Code",
+            "researcherEmail",
+            "researcher@email.com",
+            "radarText",
+            ""));
+  }
 
   @Test
   void testGetDataCustodianApprovalTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DatasetApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DatasetApprovedMessageTest.java
@@ -4,11 +4,32 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class DatasetApprovedMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User toUser = new User();
+    toUser.setDisplayName("researcher name");
+    var message =
+        new DatasetApprovedMessage(toUser, "dac name", "dataset Identifier", "dataset name");
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "dataSubmitterName",
+            "researcher name",
+            "datasetIdentifier",
+            "dataset Identifier",
+            "datasetName",
+            "dataset name",
+            "dacName",
+            "dac name"));
+  }
 
   @Test
   void testGetDatasetApprovedTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DatasetDeniedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DatasetDeniedMessageTest.java
@@ -4,11 +4,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class DatasetDeniedMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User toUser = new User();
+    toUser.setDisplayName("researcher name");
+    var message = new DatasetDeniedMessage(toUser, "dac name", "dataset name", "dac email");
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "dataSubmitterName",
+            "researcher name",
+            "datasetName",
+            "dataset name",
+            "dacName",
+            "dac name",
+            "dacEmail",
+            "dac email"));
+  }
 
   @Test
   void testGetDatasetApprovedTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DatasetSubmittedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DatasetSubmittedMessageTest.java
@@ -4,11 +4,33 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class DatasetSubmittedMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User dacChair = new User();
+    dacChair.setDisplayName("dacChairName");
+
+    var message =
+        new DatasetSubmittedMessage(dacChair, "dataSubmitterName", "testDataset", "dacName");
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "dacChairName",
+            "dacChairName",
+            "dataSubmitterName",
+            "dataSubmitterName",
+            "datasetName",
+            "testDataset",
+            "dacName",
+            "dacName"));
+  }
 
   @Test
   void testGetDatasetSubmittedTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/MailMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/MailMessageTest.java
@@ -1,0 +1,129 @@
+package org.broadinstitute.consent.http.mail.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.broadinstitute.consent.http.enumeration.EmailType;
+import org.broadinstitute.consent.http.models.User;
+import org.junit.jupiter.api.Test;
+
+class MailMessageTest {
+
+  @Test
+  void testGetTemplateName_UsesEmailTypeTemplateName() {
+    var message =
+        new TestMailMessage(
+            new User(),
+            EmailType.NEW_DAR,
+            Map.of("messageKey", "messageValue"),
+            "subject",
+            "entity-reference-id");
+
+    assertEquals(EmailType.NEW_DAR.templateName, message.getTemplateName());
+  }
+
+  @Test
+  void testCreateModel_AddsServerUrlWhenMissing() {
+    var message =
+        new TestMailMessage(
+            new User(),
+            EmailType.NEW_DAR,
+            Map.of("messageKey", "messageValue"),
+            "subject",
+            "entity-reference-id");
+
+    Map<String, Object> model = message.createModel("http://testServerUrl");
+
+    assertEquals("messageValue", model.get("messageKey"));
+    assertEquals("http://testServerUrl", model.get("serverUrl"));
+  }
+
+  @Test
+  void testCreateModel_PreservesSubclassServerUrlOverride() {
+    var message =
+        new TestMailMessage(
+            new User(),
+            EmailType.NEW_DAR,
+            Map.of("messageKey", "messageValue", "serverUrl", "http://overrideUrl"),
+            "subject",
+            "entity-reference-id");
+
+    Map<String, Object> model = message.createModel("http://testServerUrl");
+
+    assertEquals("messageValue", model.get("messageKey"));
+    assertEquals("http://overrideUrl", model.get("serverUrl"));
+  }
+
+  @Test
+  void testCreateModel_ReplacesNullSubclassServerUrl() {
+    Map<String, Object> baseModel = new HashMap<>();
+    baseModel.put("messageKey", "messageValue");
+    baseModel.put("serverUrl", null);
+    var message =
+        new TestMailMessage(
+            new User(), baseModel, EmailType.NEW_DAR, "subject", "entity-reference-id");
+
+    Map<String, Object> model = message.createModel("http://testServerUrl");
+
+    assertEquals("messageValue", model.get("messageKey"));
+    assertEquals("http://testServerUrl", model.get("serverUrl"));
+  }
+
+  @Test
+  void testGetVoteId_DefaultsToNull() {
+    var message =
+        new TestMailMessage(
+            new User(),
+            EmailType.NEW_DAR,
+            Map.of("messageKey", "messageValue"),
+            "subject",
+            "entity-reference-id");
+
+    assertNull(message.getVoteId());
+  }
+
+  private static final class TestMailMessage extends MailMessage {
+
+    private final Map<String, Object> model;
+    private final String subject;
+    private final String entityReferenceId;
+
+    private TestMailMessage(
+        User toUser,
+        EmailType emailType,
+        Map<String, Object> model,
+        String subject,
+        String entityReferenceId) {
+      this(toUser, model, emailType, subject, entityReferenceId);
+    }
+
+    private TestMailMessage(
+        User toUser,
+        Map<String, Object> model,
+        EmailType emailType,
+        String subject,
+        String entityReferenceId) {
+      super(toUser, emailType);
+      this.model = model;
+      this.subject = subject;
+      this.entityReferenceId = entityReferenceId;
+    }
+
+    @Override
+    public String createSubject() {
+      return subject;
+    }
+
+    @Override
+    public Map<String, Object> createModel() {
+      return model;
+    }
+
+    @Override
+    public String getEntityReferenceId() {
+      return entityReferenceId;
+    }
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.mail.message;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +15,23 @@ class NewCaseMessageTest extends AbstractMailMessageTest {
     assertEquals("Log vote on Data Use Limitations case id: DUL-123.", message.createSubject());
     var message2 = new NewCaseMessage(new User(), "DAR-123", "Data Access");
     assertEquals("Log votes on Data Access Request case id: DAR-123.", message2.createSubject());
+  }
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User toUser = new User();
+    toUser.setDisplayName("Test User");
+    var message = new NewCaseMessage(toUser, "DUL-123", "Data Use Limitations");
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "userName",
+            "Test User",
+            "electionType",
+            "Data Use Limitations",
+            "entityName",
+            "DUL-123"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadResearcherMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadResearcherMessageTest.java
@@ -4,10 +4,32 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class NewDAAUploadResearcherMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User researcher = new User();
+    researcher.setDisplayName("Researcher User");
+
+    var message =
+        new NewDAAUploadResearcherMessage(researcher, "DAC Name", "Previous DAA", "New DAA");
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "dacName",
+            "DAC Name",
+            "researcherUserName",
+            "Researcher User",
+            "previousDaaName",
+            "Previous DAA",
+            "newDaaName",
+            "New DAA"));
+  }
 
   @Test
   void testGetNewDaaUploadSOTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadSOMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDAAUploadSOMessageTest.java
@@ -4,10 +4,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class NewDAAUploadSOMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User signingOfficial = new User();
+    signingOfficial.setDisplayName("Signing Official User");
+
+    var message = new NewDAAUploadSOMessage(signingOfficial, "DAC Name", "Previous DAA", "New DAA");
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "dacName",
+            "DAC Name",
+            "signingOfficialUserName",
+            "Signing Official User",
+            "previousDaaName",
+            "Previous DAA",
+            "newDaaName",
+            "New DAA"));
+  }
 
   @Test
   void testGetNewDaaUploadSOTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -15,21 +14,16 @@ import org.junit.jupiter.api.Test;
 class NewDARRequestMessageTest extends AbstractMailMessageTest {
 
   @Test
-  void testCreateModel_MergesCallerProvidedModel() {
+  void testCreateModel_AddsServerUrl() {
     User toUser = new User();
     toUser.setDisplayName("Admin");
 
     var dacDatasetGroups = Map.of("DAC-01", List.of("DUOS-000001"));
     var message = new NewDARRequestMessage(toUser, "DAR-01", dacDatasetGroups, "ResearcherName");
 
-    Map<?, ?> createdModel =
-        assertInstanceOf(
-            Map.class,
-            message.createModel(
-                Map.of("serverUrl", "http://testServerUrl", "customKey", "customValue")));
+    Map<String, Object> createdModel = message.createModel("http://testServerUrl");
 
     assertEquals("http://testServerUrl", createdModel.get("serverUrl"));
-    assertEquals("customValue", createdModel.get("customKey"));
     assertEquals("Admin", createdModel.get("userName"));
     assertEquals("ResearcherName", createdModel.get("researcherUserName"));
     assertEquals("DAR-01", createdModel.get("darID"));

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
@@ -21,12 +21,17 @@ class NewDARRequestMessageTest extends AbstractMailMessageTest {
     var dacDatasetGroups = Map.of("DAC-01", List.of("DUOS-000001"));
     var message = new NewDARRequestMessage(toUser, "DAR-01", dacDatasetGroups, "ResearcherName");
 
-    Map<String, Object> createdModel = message.createModel();
-
-    assertEquals("Admin", createdModel.get("userName"));
-    assertEquals(dacDatasetGroups, createdModel.get("dacDatasetGroups"));
-    assertEquals("ResearcherName", createdModel.get("researcherUserName"));
-    assertEquals("DAR-01", createdModel.get("darID"));
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "userName",
+            "Admin",
+            "dacDatasetGroups",
+            dacDatasetGroups,
+            "researcherUserName",
+            "ResearcherName",
+            "darID",
+            "DAR-01"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.mail.message;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -12,6 +13,27 @@ import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class NewDARRequestMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_MergesCallerProvidedModel() {
+    User toUser = new User();
+    toUser.setDisplayName("Admin");
+
+    var dacDatasetGroups = Map.of("DAC-01", List.of("DUOS-000001"));
+    var message = new NewDARRequestMessage(toUser, "DAR-01", dacDatasetGroups, "ResearcherName");
+
+    Map<?, ?> createdModel =
+        assertInstanceOf(
+            Map.class,
+            message.createModel(
+                Map.of("serverUrl", "http://testServerUrl", "customKey", "customValue")));
+
+    assertEquals("http://testServerUrl", createdModel.get("serverUrl"));
+    assertEquals("customValue", createdModel.get("customKey"));
+    assertEquals("Admin", createdModel.get("userName"));
+    assertEquals("ResearcherName", createdModel.get("researcherUserName"));
+    assertEquals("DAR-01", createdModel.get("darID"));
+  }
 
   @Test
   void testGetNewDARRequestTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
@@ -14,17 +14,17 @@ import org.junit.jupiter.api.Test;
 class NewDARRequestMessageTest extends AbstractMailMessageTest {
 
   @Test
-  void testCreateModel_AddsServerUrl() {
+  void testCreateModel_AddsNewDarRequestFields() {
     User toUser = new User();
     toUser.setDisplayName("Admin");
 
     var dacDatasetGroups = Map.of("DAC-01", List.of("DUOS-000001"));
     var message = new NewDARRequestMessage(toUser, "DAR-01", dacDatasetGroups, "ResearcherName");
 
-    Map<String, Object> createdModel = message.createModel("http://testServerUrl");
+    Map<String, Object> createdModel = message.createModel();
 
-    assertEquals("http://testServerUrl", createdModel.get("serverUrl"));
     assertEquals("Admin", createdModel.get("userName"));
+    assertEquals(dacDatasetGroups, createdModel.get("dacDatasetGroups"));
     assertEquals("ResearcherName", createdModel.get("researcherUserName"));
     assertEquals("DAR-01", createdModel.get("darID"));
   }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARSigningOfficialRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARSigningOfficialRequestMessageTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.mail.message;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -10,6 +11,18 @@ import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class NewDARSigningOfficialRequestMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User signingOfficial = new User();
+    signingOfficial.setDisplayName("SO");
+    var message =
+        new NewDARSigningOfficialRequestMessage(signingOfficial, "DAR-01", "ResearcherName");
+
+    assertRequiredModelFields(
+        message,
+        Map.of("userName", "SO", "researcherUserName", "ResearcherName", "darID", "DAR-01"));
+  }
 
   @Test
   void testGetNewDARRequestTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessageTest.java
@@ -5,11 +5,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class NewLibraryCardIssuedMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User toUser = new User();
+    toUser.setDisplayName("Test User");
+    var message = new NewLibraryCardIssuedMessage(toUser);
+
+    assertRequiredModelFields(message, Map.of("displayName", "Test User"));
+  }
 
   @Test
   void testNewLibraryCardIssuedTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewProgressReportCaseMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewProgressReportCaseMessageTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.mail.message;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,15 @@ class NewProgressReportCaseMessageTest extends AbstractMailMessageTest {
   void testMessageSubject() {
     var message2 = new NewProgressReportCaseMessage(new User(), "DAR-123");
     assertEquals("Log votes on Progress Report case id: DAR-123.", message2.createSubject());
+  }
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User toUser = new User();
+    toUser.setDisplayName("Test User");
+    var message = new NewProgressReportCaseMessage(toUser, "DAR-123");
+
+    assertRequiredModelFields(message, Map.of("userName", "Test User", "entityName", "DAR-123"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessageTest.java
@@ -14,6 +14,28 @@ import org.junit.jupiter.api.Test;
 class NewProgressReportRequestMessageTest extends AbstractMailMessageTest {
 
   @Test
+  void testCreateModel_AddsRequiredFields() {
+    User toUser = new User();
+    toUser.setDisplayName("Admin");
+    var dacDatasetGroups = Map.of("DAC-01", List.of("DUOS-000001"));
+    var message =
+        new NewProgressReportRequestMessage(
+            toUser, "DAR-01", "myReferenceId", dacDatasetGroups, "ResearcherName");
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "userName",
+            "Admin",
+            "dacDatasetGroups",
+            dacDatasetGroups,
+            "researcherUserName",
+            "ResearcherName",
+            "darID",
+            "DAR-01"));
+  }
+
+  @Test
   void testGetNewDARRequestTemplate() throws Exception {
     User toUser = new User();
     toUser.setDisplayName("Admin");

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
@@ -8,12 +8,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.StudyDatasetCountRecord;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class NewStudyDigestMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    List<StudyDatasetCountRecord> newStudies =
+        List.of(
+            new StudyDatasetCountRecord("My new study", 3, 1),
+            new StudyDatasetCountRecord("My other new study", 4000, 2));
+    User user = new User();
+    user.setDisplayName("Test User");
+    var message = new NewStudyDigestMessage(user, newStudies, "My reference id");
+
+    assertRequiredModelFields(message, Map.of("userName", "Test User", "newStudies", newStudies));
+  }
 
   @Test
   void testNewStudyDigestMessage() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyRegistrationConfirmationMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyRegistrationConfirmationMessageTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -8,6 +9,29 @@ import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class NewStudyRegistrationConfirmationMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User submitter = new User();
+    submitter.setDisplayName("Test User");
+    Map<String, Object> assets = Map.of("assetType", List.of("asset1"));
+
+    var message =
+        new NewStudyRegistrationConfirmationMessage(submitter, "Cancer Research", 123, assets);
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "studySubmitterName",
+            "Test User",
+            "studyName",
+            "Cancer Research",
+            "studyId",
+            123,
+            "studyAssets",
+            assets));
+    assertEquals("Cancer Research", message.getEntityReferenceId());
+  }
 
   @Test
   void testMessageTemplate_singleAsset() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.mail.message;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
@@ -48,5 +49,23 @@ class ReminderMessageTest extends AbstractMailMessageTest {
         Objects.requireNonNull(rendered.document().getElementById("userName")).text());
     assertTrue(rendered.content().contains(darCode));
     assertTrue(rendered.content().contains(voteUrl));
+  }
+
+  @Test
+  void testCreateModel_PreservesVoteUrlServerUrlOverride() {
+    User toUser = new User();
+    toUser.setDisplayName("Reminder User");
+    Vote vote = new Vote();
+    vote.setVoteId(1);
+    vote.setElectionId(123);
+    String voteUrl = "http://testVoteUrl";
+
+    var message = new ReminderMessage(toUser, vote, "DUL-123", "Data Use Limitations", voteUrl);
+
+    Map<String, Object> model = message.createModel("http://defaultServerUrl");
+
+    assertEquals(voteUrl, model.get("serverUrl"));
+    assertEquals("Reminder User", model.get("userName"));
+    assertEquals("DUL-123", model.get("entityName"));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherCloseoutCompletedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherCloseoutCompletedMessageTest.java
@@ -4,11 +4,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.UUID;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class ResearcherCloseoutCompletedMessageTest extends AbstractMailMessageTest {
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User requestUser = new User();
+    requestUser.setDisplayName("Test User");
+    var message =
+        new ResearcherCloseoutCompletedMessage(
+            requestUser, "DAR-123", UUID.randomUUID().toString());
+
+    assertRequiredModelFields(message, Map.of("userName", "Test User", "darCode", "DAR-123"));
+  }
 
   @Test
   void testGetResearcherCloseoutCompletedTemplate() throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherDarApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherDarApprovedMessageTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,33 @@ class ResearcherDarApprovedMessageTest extends AbstractMailMessageTest {
   void testMessageSubject() {
     var message = new ResearcherDarApprovedMessage(new User(), "DAR-123", List.of(), "", false);
     assertEquals("Your DUOS Data Access Request Results", message.createSubject());
+  }
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User researcher = new User();
+    researcher.setDisplayName("Researcher User");
+    researcher.setEmail("researcher@test.com");
+    List<DatasetMailDTO> datasets =
+        List.of(new DatasetMailDTO("dataset-name", "DUOS-00001", "gs://bucket/object"));
+    var message =
+        new ResearcherDarApprovedMessage(researcher, "DAR-123", datasets, "General Use", false);
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "researcherName",
+            "Researcher User",
+            "darCode",
+            "DAR-123",
+            "datasets",
+            datasets,
+            "dataUseRestriction",
+            "General Use",
+            "radarText",
+            "",
+            "researcherEmail",
+            "researcher@test.com"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherProgressReportApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherProgressReportApprovedMessageTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,34 @@ class ResearcherProgressReportApprovedMessageTest extends AbstractMailMessageTes
     var message =
         new ResearcherApprovedProgressReportMessage(new User(), "DAR-123", List.of(), "", false);
     assertEquals("Your DUOS Progress Report Results", message.createSubject());
+  }
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    User researcher = new User();
+    researcher.setDisplayName("Researcher User");
+    researcher.setEmail("researcher@test.com");
+    List<DatasetMailDTO> datasets =
+        List.of(new DatasetMailDTO("dataset-name", "DUOS-00001", "gs://bucket/object"));
+    var message =
+        new ResearcherApprovedProgressReportMessage(
+            researcher, "DAR-123", datasets, "General Use", false);
+
+    assertRequiredModelFields(
+        message,
+        Map.of(
+            "researcherName",
+            "Researcher User",
+            "darCode",
+            "DAR-123",
+            "datasets",
+            datasets,
+            "dataUseRestriction",
+            "General Use",
+            "radarText",
+            "",
+            "researcherEmail",
+            "researcher@test.com"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/SigningOfficialMessagesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/SigningOfficialMessagesTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
@@ -65,6 +66,44 @@ class SigningOfficialMessagesTest extends AbstractMailMessageTest {
   void testMessageSubject(MailMessage message) {
     assertTrue(
         message.createSubject().contains("Broad Data Use Oversight System - Signing Official"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("messageProvider")
+  void testCreateModel_AddsRequiredFields(MailMessage message) {
+    String radarText =
+        message.createSubject().contains("RADAR") ? "Rule Automated DAR (RADAR) " : "";
+    if (message instanceof SoDARApproved || message instanceof SoPRApproved) {
+      assertRequiredModelFields(
+          message,
+          Map.of(
+              "userName",
+              toUser.getDisplayName(),
+              "darCode",
+              DAR_CODE,
+              "radarText",
+              radarText,
+              "researcherUserName",
+              researcher.getDisplayName(),
+              "researcherEmail",
+              researcher.getEmail(),
+              "datasets",
+              datasets,
+              "dataUseRestriction",
+              TRANSLATION));
+    } else {
+      assertRequiredModelFields(
+          message,
+          Map.of(
+              "userName",
+              toUser.getDisplayName(),
+              "darCode",
+              DAR_CODE,
+              "researcherUserName",
+              researcher.getDisplayName(),
+              "datasets",
+              datasets));
+    }
   }
 
   @ParameterizedTest

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/SubmittedCloseoutMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/SubmittedCloseoutMessageTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.mail.message;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +24,16 @@ class SubmittedCloseoutMessageTest extends AbstractMailMessageTest {
     var message =
         new SubmittedCloseoutMessage(toUser, "DAR-123", "ref-456", "http://testServerUrl");
     assertEquals("DAR DAR-123 Closeout Available for Review", message.createSubject());
+  }
+
+  @Test
+  void testCreateModel_AddsRequiredFields() {
+    var message =
+        new SubmittedCloseoutMessage(toUser, "DAR-123", "ref-456", "http://testServerUrl");
+
+    assertRequiredModelFields(
+        message,
+        Map.of("displayName", "Test User", "darId", "DAR-123", "linkUrl", "http://testServerUrl"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -525,8 +525,8 @@ class EmailServiceTest extends AbstractTestHelper {
       }
 
       @Override
-      public Object createModel(Map<String, Object> model) {
-        return model;
+      public Map<String, Object> createModel() {
+        return Map.of();
       }
 
       @Override

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -102,13 +102,11 @@ class EmailServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setEmail(userEmail);
     String subject = "subject";
-    Map<String, Object> model = Map.of("key", "value");
     String entityReferenceId = "entityReferenceId";
     Integer userId = 1234;
     Integer voteId = 4567;
     var message =
-        createMailMessage(
-            user, EmailType.NEW_CASE, subject, model, entityReferenceId, voteId, null);
+        createMailMessage(user, EmailType.NEW_CASE, subject, entityReferenceId, voteId, null);
     Template template = mock();
     when(templateHelper.getTemplate(EmailType.NEW_CASE.templateName)).thenReturn(template);
     Response response = new Response();
@@ -119,7 +117,7 @@ class EmailServiceTest extends AbstractTestHelper {
     doNothing()
         .when(template)
         .process(
-            eq(model),
+            eq(Map.of("serverUrl", SERVER_URL)),
             argThat(
                 writer -> {
                   try {
@@ -173,13 +171,12 @@ class EmailServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setEmail(userEmail);
     String subject = "subject";
-    Map<String, Object> model = Map.of("key", "value");
     String entityReferenceId = "entityReferenceId";
     Integer userId = 1234;
     String templateName = "test-template.ftl";
     var message =
         createMailMessage(
-            user, EmailType.NEW_DAA_REQUEST, subject, model, entityReferenceId, null, templateName);
+            user, EmailType.NEW_DAA_REQUEST, subject, entityReferenceId, null, templateName);
     Template template = mock();
     when(templateHelper.getTemplate(templateName)).thenReturn(template);
     when(sendGridAPI.sendMessage(any(), any())).thenReturn(null);
@@ -187,7 +184,7 @@ class EmailServiceTest extends AbstractTestHelper {
     doNothing()
         .when(template)
         .process(
-            eq(model),
+            eq(Map.of("serverUrl", SERVER_URL)),
             argThat(
                 writer -> {
                   try {
@@ -225,13 +222,11 @@ class EmailServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setEmail(userEmail);
     String subject = "subject";
-    Map<String, Object> model = Map.of("key", "value");
     String entityReferenceId = "entityReferenceId";
     Integer userId = 1234;
     Integer voteId = 4567;
     var message =
-        createMailMessage(
-            user, EmailType.NEW_CASE, subject, model, entityReferenceId, voteId, null);
+        createMailMessage(user, EmailType.NEW_CASE, subject, entityReferenceId, voteId, null);
     Template template = mock();
     when(templateHelper.getTemplate(EmailType.NEW_CASE.templateName)).thenReturn(template);
     Response response = new Response();
@@ -242,7 +237,7 @@ class EmailServiceTest extends AbstractTestHelper {
     doNothing()
         .when(template)
         .process(
-            eq(model),
+            eq(Map.of("serverUrl", SERVER_URL)),
             argThat(
                 writer -> {
                   try {
@@ -515,7 +510,6 @@ class EmailServiceTest extends AbstractTestHelper {
       User user,
       EmailType emailType,
       String subject,
-      Object model,
       String entityReferenceId,
       Integer voteId,
       String templateNameOverride) {
@@ -531,7 +525,7 @@ class EmailServiceTest extends AbstractTestHelper {
       }
 
       @Override
-      public Object createModel(String serverUrl) {
+      public Object createModel(Map<String, Object> model) {
         return model;
       }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1591

Specifically, this part of the ticket:
> MailMessage.createModel() accepts serverUrl so it can be added to the replacement dictionary passed to FreeMarker. If createModel() returned Map<String, Object> instead, and if serverUrl is always referred to using that name in the mail templates, the caller could add serverUrl to the returned Map and avoid passing in serverUrl.

## Summary
This PR simplifies mail message model construction by changing `MailMessage` subclasses to return a `Map<String, Object>` directly and moving `serverUrl` injection into the base `MailMessage` class.

### What changed

- changed mail message subclasses to implement no-arg `createModel()`
- added `MailMessage.createModel(String serverUrl)` as a wrapper that injects `serverUrl`
- used `putIfAbsent` so message-specific `serverUrl` overrides are preserved
- removed the caller-provided model merge approach
- updated `EmailService` to render templates with the centralized wrapper
- normalized `new-library-card-issued.ftl` to use `serverUrl`
- updated tests covering mail message model creation and email rendering

### Why

The original goal was to avoid passing `serverUrl` into each message-specific model builder while still making it available to FreeMarker templates. This change keeps message classes focused on their own data and centralizes shared template context in one place.

### Behavior notes

- default mail templates still receive `serverUrl`
- `ReminderMessage` continues to override `serverUrl` with its vote URL
- `new-library-card-issued.ftl` now uses `${serverUrl}datalibrary`

### Testing changes

- Moved generic MailMessage behavior tests out of NewDARRequestMessageTest into a new MailMessageTest
- Added shared test helpers in AbstractMailMessageTest for asserting required createModel() fields
- Added/expanded testCreateModel_AddsRequiredFields coverage across mail message test classes
- Kept message-specific template assertions in the individual test classes

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
