### PR TITLE
DT-3295: Re-add surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,20 @@
     <plugins>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <!-- @{argLine} is necessary here so that the jacoco:prepare-agent output is included for tests -->
+          <!-- Updated configuration for mockito-->
+          <argLine>@{argLine} -Xmx1024m -XX:TieredStopAtLevel=1
+            -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+            -Xshare:off
+          </argLine>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3295

### Summary
In https://github.com/DataBiosphere/consent/pull/2891, we removed two conditional surefire blocks. We should have kept the first one in place and only removed the integration test profile block. Tests still run regardless, but we get a warning:
```
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
```
so using the plugin explicitly gives us better control over the fine-grained jvm settings.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
