### PR TITLE
DT-3236: Add Unsubscribe Feature

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/configurations/MailConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/MailConfiguration.java
@@ -14,6 +14,9 @@ public class MailConfiguration {
 
   @NotNull private String sendGridStatusUrl;
 
+  // Nullable — absent in test configs is fine
+  private Integer sendGridUnsubscribeGroupId;
+
   public boolean isActivateEmailNotifications() {
     return activateEmailNotifications;
   }
@@ -44,5 +47,13 @@ public class MailConfiguration {
 
   public void setSendGridStatusUrl(String sendGridStatusUrl) {
     this.sendGridStatusUrl = sendGridStatusUrl;
+  }
+
+  public Integer getSendGridUnsubscribeGroupId() {
+    return sendGridUnsubscribeGroupId;
+  }
+
+  public void setSendGridUnsubscribeGroupId(Integer sendGridUnsubscribeGroupId) {
+    this.sendGridUnsubscribeGroupId = sendGridUnsubscribeGroupId;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/mail/SendGridAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/SendGridAPI.java
@@ -61,7 +61,7 @@ public class SendGridAPI implements ConsentLogger {
     }
 
     // Attach ASM block so SendGrid can render the unsubscribe URL
-    if (unsubscribeGroupId != null) {
+    if (unsubscribeGroupId != null && unsubscribeGroupId > 0) {
       ASM asm = new ASM();
       asm.setGroupId(unsubscribeGroupId);
       // groupsToDisplay controls which groups appear on the SendGrid

--- a/src/main/java/org/broadinstitute/consent/http/mail/SendGridAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/SendGridAPI.java
@@ -6,10 +6,12 @@ import com.sendgrid.Request;
 import com.sendgrid.Response;
 import com.sendgrid.SendGrid;
 import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.ASM;
 import jakarta.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.User;
@@ -19,6 +21,7 @@ public class SendGridAPI implements ConsentLogger {
 
   private final SendGrid sendGrid;
   private final boolean activateEmailNotifications;
+  @Nullable private final Integer unsubscribeGroupId;
 
   private final UserDAO userDAO;
 
@@ -26,6 +29,7 @@ public class SendGridAPI implements ConsentLogger {
     this.sendGrid = new SendGrid(config.getSendGridApiKey());
     this.activateEmailNotifications = config.isActivateEmailNotifications();
     this.userDAO = userDAO;
+    this.unsubscribeGroupId = config.getSendGridUnsubscribeGroupId();
   }
 
   /**
@@ -55,6 +59,18 @@ public class SendGridAPI implements ConsentLogger {
               .formatted(toUserEmail));
       return null;
     }
+
+    // Attach ASM block so SendGrid can render the unsubscribe URL
+    if (unsubscribeGroupId != null) {
+      ASM asm = new ASM();
+      asm.setGroupId(unsubscribeGroupId);
+      // groupsToDisplay controls which groups appear on the SendGrid
+      // preference center page if you link to it. A single-element array
+      // showing just this group is the right default.
+      asm.setGroupsToDisplay(new int[] {unsubscribeGroupId});
+      message.setASM(asm);
+    }
+
     try {
       // See https://github.com/sendgrid/sendgrid-java/issues/163
       // for what actually works as compared to the documentation - which doesn't.

--- a/src/main/resources/freemarker/footer.ftl
+++ b/src/main/resources/freemarker/footer.ftl
@@ -1,4 +1,25 @@
 <!-- Shared footer to close the common layout started by header.ftl -->
+      <tr>
+        <td style="padding: 30px 15px 10px; border-top: 1px solid #D9E2EC; text-align: center;
+                       font-family: 'Montserrat', sans-serif; font-size: 12px; color: #8492A6;
+                       line-height: 20px;">
+          <p style="margin: 0 0 6px;">
+            You are receiving this email because you have an account in the
+            <a href="https://duos.org" style="color: #00609F; text-decoration: none;">
+              Broad Data Use Oversight System (DUOS)
+            </a>.
+          </p>
+          <p style="margin: 0 0 6px;">
+            Broad Institute of MIT and Harvard &bull; 415 Main Street, Cambridge, MA 02142
+          </p>
+          <p style="margin: 0;">
+            <a href="<%asm_group_unsubscribe_url%>"
+               style="color: #00609F; text-decoration: underline; font-size: 12px;">
+              Unsubscribe from DUOS email notifications
+            </a>
+          </p>
+        </td>
+      </tr>
     </table>
   </div>
 </body>

--- a/src/main/resources/freemarker/footer.ftl
+++ b/src/main/resources/freemarker/footer.ftl
@@ -21,7 +21,7 @@
             </p>
           <#else>
             <p style="margin: 0;">
-              To manage DUOS email notifications, please sign in to DUOS.
+              To manage DUOS email notifications, please sign in to <a href="https://duos.org/profile" style="color: #00609F; text-decoration: none;">DUOS</a>.
             </p>
           </#if>
         </td>

--- a/src/main/resources/freemarker/footer.ftl
+++ b/src/main/resources/freemarker/footer.ftl
@@ -12,12 +12,18 @@
           <p style="margin: 0 0 6px;">
             Broad Institute &bull; Merkin Building, 415 Main Street, Cambridge, MA 02142
           </p>
-          <p style="margin: 0;">
-            <a href="<%asm_group_unsubscribe_raw_url%>"
-               style="color: #00609F; text-decoration: underline; font-size: 12px;">
-              Unsubscribe from DUOS email notifications
-            </a>
-          </p>
+          <#if sendGridUnsubscribeGroupId?? && sendGridUnsubscribeGroupId?has_content>
+            <p style="margin: 0;">
+              <a href="<%asm_group_unsubscribe_raw_url%>"
+                 style="color: #00609F; text-decoration: underline; font-size: 12px;">
+                Unsubscribe from DUOS email notifications
+              </a>
+            </p>
+          <#else>
+            <p style="margin: 0;">
+              To manage DUOS email notifications, please sign in to DUOS.
+            </p>
+          </#if>
         </td>
       </tr>
     </table>

--- a/src/main/resources/freemarker/footer.ftl
+++ b/src/main/resources/freemarker/footer.ftl
@@ -13,7 +13,7 @@
             Broad Institute of MIT and Harvard &bull; 415 Main Street, Cambridge, MA 02142
           </p>
           <p style="margin: 0;">
-            <a href="<%asm_group_unsubscribe_url%>"
+            <a href="<%asm_group_unsubscribe_raw_url%>"
                style="color: #00609F; text-decoration: underline; font-size: 12px;">
               Unsubscribe from DUOS email notifications
             </a>

--- a/src/main/resources/freemarker/footer.ftl
+++ b/src/main/resources/freemarker/footer.ftl
@@ -10,7 +10,7 @@
             </a>.
           </p>
           <p style="margin: 0 0 6px;">
-            Broad Institute of MIT and Harvard &bull; 415 Main Street, Cambridge, MA 02142
+            Broad Institute &bull; Merkin Building, 415 Main Street, Cambridge, MA 02142
           </p>
           <p style="margin: 0;">
             <a href="<%asm_group_unsubscribe_raw_url%>"

--- a/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
@@ -59,12 +59,14 @@ class FreeMarkerTemplateHelperTest {
   }
 
   @Test
-  void renderedTemplateFallsBackWhenAsmUnsubscribeGroupMissing() throws Exception {
+  void renderedTemplateShowsDuosProfileLinkWhenAsmUnsubscribeGroupMissing() throws Exception {
     String renderedTemplate =
         renderTemplate(Map.of("researcherName", "Synthetic User", "darCode", "DAR-123"));
 
+    assertTrue(renderedTemplate.contains("To manage DUOS email notifications, please sign in to"));
     assertTrue(
-        renderedTemplate.contains("To manage DUOS email notifications, please sign in to DUOS."));
+        renderedTemplate.contains(
+            "<a href=\"https://duos.org/profile\" style=\"color: #00609F; text-decoration: none;\">DUOS</a>"));
     assertFalse(renderedTemplate.contains("<%asm_group_unsubscribe_raw_url%>"));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
@@ -1,12 +1,15 @@
 package org.broadinstitute.consent.http.mail.freemarker;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
+import java.io.StringWriter;
+import java.util.Map;
 import org.broadinstitute.consent.http.configurations.FreeMarkerConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,5 +43,20 @@ class FreeMarkerTemplateHelperTest {
     var expectedPath = "freemarker/%s".formatted(templateName);
     when(mockedConfiguration.getTemplate(expectedPath)).thenReturn(template);
     assertEquals(template, freeMarkerTemplateHelper.getTemplate(templateName));
+  }
+
+  @Test
+  void renderedTemplatePreservesRawAsmUnsubscribeToken() throws Exception {
+    FreeMarkerConfiguration fmConfig = new FreeMarkerConfiguration();
+    fmConfig.setTemplateDirectory("freemarker");
+    fmConfig.setDefaultEncoding("UTF-8");
+
+    FreeMarkerTemplateHelper realTemplateHelper = new FreeMarkerTemplateHelper(fmConfig);
+    Template template = realTemplateHelper.getTemplate("dar-expired.ftl");
+    StringWriter out = new StringWriter();
+
+    template.process(Map.of("researcherName", "Synthetic User", "darCode", "DAR-123"), out);
+
+    assertTrue(out.toString().contains("href=\"<%asm_group_unsubscribe_raw_url%>\""));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
@@ -47,6 +47,26 @@ class FreeMarkerTemplateHelperTest {
 
   @Test
   void renderedTemplatePreservesRawAsmUnsubscribeToken() throws Exception {
+    String renderedTemplate =
+        renderTemplate(
+            Map.of(
+                "researcherName", "Synthetic User",
+                "darCode", "DAR-123",
+                "sendGridUnsubscribeGroupId", 12345));
+
+    assertTrue(renderedTemplate.contains("href=\"<%asm_group_unsubscribe_raw_url%>\""));
+  }
+
+  @Test
+  void renderedTemplateFallsBackWhenAsmUnsubscribeGroupMissing() throws Exception {
+    String renderedTemplate =
+        renderTemplate(Map.of("researcherName", "Synthetic User", "darCode", "DAR-123"));
+
+    assertTrue(
+        renderedTemplate.contains("To manage DUOS email notifications, please sign in to DUOS."));
+  }
+
+  private String renderTemplate(Map<String, Object> model) throws Exception {
     FreeMarkerConfiguration fmConfig = new FreeMarkerConfiguration();
     fmConfig.setTemplateDirectory("freemarker");
     fmConfig.setDefaultEncoding("UTF-8");
@@ -55,8 +75,8 @@ class FreeMarkerTemplateHelperTest {
     Template template = realTemplateHelper.getTemplate("dar-expired.ftl");
     StringWriter out = new StringWriter();
 
-    template.process(Map.of("researcherName", "Synthetic User", "darCode", "DAR-123"), out);
+    template.process(model, out);
 
-    assertTrue(out.toString().contains("href=\"<%asm_group_unsubscribe_raw_url%>\""));
+    return out.toString();
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.mail.freemarker;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -64,6 +65,7 @@ class FreeMarkerTemplateHelperTest {
 
     assertTrue(
         renderedTemplate.contains("To manage DUOS email notifications, please sign in to DUOS."));
+    assertFalse(renderedTemplate.contains("<%asm_group_unsubscribe_raw_url%>"));
   }
 
   private String renderTemplate(Map<String, Object> model) throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/service/mail/SendGridAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/mail/SendGridAPITest.java
@@ -1,7 +1,9 @@
 package org.broadinstitute.consent.http.service.mail;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.reset;
@@ -14,6 +16,8 @@ import com.sendgrid.Request;
 import com.sendgrid.Response;
 import com.sendgrid.SendGrid;
 import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
 import java.io.IOException;
 import java.util.Map;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
@@ -32,6 +36,7 @@ class SendGridAPITest {
 
   private static final String FROM = "from@broadinstitute.org";
   private static final String TO = "to@broadinstitute.org";
+  private static final int UNSUBSCRIBE_GROUP_ID = 12345;
   private static final Response RESPONSE = new Response();
 
   private SendGrid sendGrid;
@@ -46,7 +51,7 @@ class SendGridAPITest {
     config.setActivateEmailNotifications(true);
     try (var mockedSendGrid = mockConstruction(SendGrid.class)) {
       sendGridAPI = new SendGridAPI(config, userDAO);
-      sendGrid = mockedSendGrid.constructed().get(0);
+      sendGrid = mockedSendGrid.constructed().getFirst();
     }
     when(userDAO.findUserByEmail(TO)).thenReturn(new User());
     when(sendGrid.makeCall(any())).thenReturn(RESPONSE);
@@ -66,6 +71,41 @@ class SendGridAPITest {
     ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
     verify(sendGrid).makeCall(requestCaptor.capture());
     assertEquals(messageBody, requestCaptor.getValue().getBody());
+  }
+
+  @Test
+  void sendMessageAttachesAsmWhenGroupConfigured() throws Exception {
+    try (var mockedSendGrid = mockConstruction(SendGrid.class)) {
+      MailConfiguration config = new MailConfiguration();
+      config.setGoogleAccount(FROM);
+      config.setActivateEmailNotifications(true);
+      config.setSendGridUnsubscribeGroupId(UNSUBSCRIBE_GROUP_ID);
+      SendGridAPI configuredSendGridApi = new SendGridAPI(config, userDAO);
+      SendGrid configuredSendGrid = mockedSendGrid.constructed().getFirst();
+      when(configuredSendGrid.makeCall(any())).thenReturn(RESPONSE);
+
+      Mail mail =
+          new Mail(new Email(FROM), "Subject", new Email(TO), new Content("text/html", "Body"));
+
+      assertEquals(RESPONSE, configuredSendGridApi.sendMessage(mail, TO));
+
+      ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+      verify(configuredSendGrid).makeCall(requestCaptor.capture());
+      assertTrue(requestCaptor.getValue().getBody().contains("\"group_id\":12345"));
+      assertTrue(requestCaptor.getValue().getBody().contains("\"groups_to_display\":[12345]"));
+    }
+  }
+
+  @Test
+  void sendMessageDoesNotAttachAsmWhenGroupMissing() throws Exception {
+    Mail mail =
+        new Mail(new Email(FROM), "Subject", new Email(TO), new Content("text/html", "Body"));
+
+    assertEquals(RESPONSE, sendGridAPI.sendMessage(mail, TO));
+
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+    verify(sendGrid).makeCall(requestCaptor.capture());
+    assertFalse(requestCaptor.getValue().getBody().contains("\"asm\":"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/mail/SendGridAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/mail/SendGridAPITest.java
@@ -1,9 +1,8 @@
 package org.broadinstitute.consent.http.service.mail;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.reset;
@@ -89,10 +88,9 @@ class SendGridAPITest {
 
       assertEquals(RESPONSE, configuredSendGridApi.sendMessage(mail, TO));
 
-      ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
-      verify(configuredSendGrid).makeCall(requestCaptor.capture());
-      assertTrue(requestCaptor.getValue().getBody().contains("\"group_id\":12345"));
-      assertTrue(requestCaptor.getValue().getBody().contains("\"groups_to_display\":[12345]"));
+      verify(configuredSendGrid).makeCall(any());
+      assertEquals(UNSUBSCRIBE_GROUP_ID, mail.getASM().getGroupId());
+      assertArrayEquals(new int[] {UNSUBSCRIBE_GROUP_ID}, mail.getASM().getGroupsToDisplay());
     }
   }
 
@@ -103,9 +101,8 @@ class SendGridAPITest {
 
     assertEquals(RESPONSE, sendGridAPI.sendMessage(mail, TO));
 
-    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
-    verify(sendGrid).makeCall(requestCaptor.capture());
-    assertFalse(requestCaptor.getValue().getBody().contains("\"asm\":"));
+    verify(sendGrid).makeCall(any());
+    assertNull(mail.getASM());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/mail/SendGridAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/mail/SendGridAPITest.java
@@ -107,19 +107,24 @@ class SendGridAPITest {
 
   @Test
   void sendMessageDoesNotAttachAsmWhenGroupInvalid() throws Exception {
-    MailConfiguration config = new MailConfiguration();
-    config.setGoogleAccount(FROM);
-    config.setActivateEmailNotifications(true);
-    config.setSendGridUnsubscribeGroupId(0); // invalid group ID should be treated as missing/absent
-    SendGridAPI configuredSendGridApi = new SendGridAPI(config, userDAO);
+    try (var mockedSendGrid = mockConstruction(SendGrid.class)) {
+      MailConfiguration config = new MailConfiguration();
+      config.setGoogleAccount(FROM);
+      config.setActivateEmailNotifications(true);
+      // invalid group ID should be treated as missing/absent
+      config.setSendGridUnsubscribeGroupId(0);
+      SendGridAPI configuredSendGridApi = new SendGridAPI(config, userDAO);
+      SendGrid configuredSendGrid = mockedSendGrid.constructed().getFirst();
+      when(configuredSendGrid.makeCall(any())).thenReturn(RESPONSE);
 
-    Mail mail =
-        new Mail(new Email(FROM), "Subject", new Email(TO), new Content("text/html", "Body"));
+      Mail mail =
+          new Mail(new Email(FROM), "Subject", new Email(TO), new Content("text/html", "Body"));
 
-    assertEquals(RESPONSE, sendGridAPI.sendMessage(mail, TO));
+      assertEquals(RESPONSE, configuredSendGridApi.sendMessage(mail, TO));
 
-    verify(sendGrid).makeCall(any());
-    assertNull(mail.getASM());
+      verify(configuredSendGrid).makeCall(any());
+      assertNull(mail.getASM());
+    }
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/mail/SendGridAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/mail/SendGridAPITest.java
@@ -106,6 +106,23 @@ class SendGridAPITest {
   }
 
   @Test
+  void sendMessageDoesNotAttachAsmWhenGroupInvalid() throws Exception {
+    MailConfiguration config = new MailConfiguration();
+    config.setGoogleAccount(FROM);
+    config.setActivateEmailNotifications(true);
+    config.setSendGridUnsubscribeGroupId(0); // invalid group ID should be treated as missing/absent
+    SendGridAPI configuredSendGridApi = new SendGridAPI(config, userDAO);
+
+    Mail mail =
+        new Mail(new Email(FROM), "Subject", new Email(TO), new Content("text/html", "Body"));
+
+    assertEquals(RESPONSE, sendGridAPI.sendMessage(mail, TO));
+
+    verify(sendGrid).makeCall(any());
+    assertNull(mail.getASM());
+  }
+
+  @Test
   void sendMessageUserMissing() {
     reset(userDAO);
     reset(sendGrid);

--- a/src/test/resources/consent-config.yml
+++ b/src/test/resources/consent-config.yml
@@ -45,6 +45,7 @@ mailConfiguration:
   googleAccount: test@gmail.com
   sendGridApiKey: test-key
   sendGridStatusUrl: test-sg-status
+  sendGridUnsubscribeGroupId: 0
 freeMarkerConfiguration:
   templateDirectory: /freemarker
   defaultEncoding: UTF-8

--- a/src/test/resources/consent-config.yml
+++ b/src/test/resources/consent-config.yml
@@ -45,7 +45,7 @@ mailConfiguration:
   googleAccount: test@gmail.com
   sendGridApiKey: test-key
   sendGridStatusUrl: test-sg-status
-  sendGridUnsubscribeGroupId: 0
+  sendGridUnsubscribeGroupId: null
 freeMarkerConfiguration:
   templateDirectory: /freemarker
   defaultEncoding: UTF-8


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-3236

## Summary
Requires https://github.com/broadinstitute/terra-helmfile/pull/6441

- Adds content to a shared email footer (`footer.ftl`) rendered in every outgoing DUOS notification with a visible unsubscribe link, physical mailing address, and account origin notice
- Wires SendGrid's Advanced Suppression Manager (ASM) into `SendGridAPI` so the unsubscribe link is backed by a real suppression group
- Adds `sendGridUnsubscribeGroupId` to `MailConfiguration` with a nullable/optional contract so existing environments without the value configured continue to function

### How the unsubscribe link works

The footer template contains the SendGrid substitution tag `<%asm_group_unsubscribe_raw_url%>`. This tag is **not rendered by our application** — it is a server-side token that SendGrid replaces with a per-recipient, signed unsubscribe URL when the email is delivered.

For SendGrid to expand that token, the outgoing API payload must include an `asm` block identifying which suppression group the email belongs to. `SendGridAPI.sendMessage` now attaches that block when `sendGridUnsubscribeGroupId` is configured:

```json
"asm": {
  "group_id": 12345,
  "groups_to_display": [12345]
}
```

When a recipient clicks the link, SendGrid records the opt-out against that group and suppresses future sends to that address for any email tagged with the same group. The _raw_ variant of the tag produces a direct unsubscribe URL rather than one that also tracks the click.

The subdomain used in the generated URL (e.g. url5514.broadinstitute.org) is a CNAME configured in Broadinstitute DNS that points to SendGrid's tracking infrastructure. It is managed in the SendGrid dashboard under Sender Authentication → Link Branding and is not controlled by this codebase.

### CAN-SPAM compliance
The [CAN-SPAM Act](https://www.ftc.gov/business-guidance/resources/can-spam-act-compliance-guide-business) requires every commercial/transactional email to include:

Requirement | How this PR satisfies it
-- | --
A clear and conspicuous opt-out mechanism | The "Unsubscribe from DUOS email notifications" link appears in the footer of every email
Opt-out honored within 10 business days | SendGrid ASM suppresses the address immediately and permanently on click — no code change required on our end
Physical postal address of the sender | "Broad Institute • Merkin Building, 415 Main Street, Cambridge, MA 02142" is rendered in every footer (see [bi.org for current address standard](https://www.broadinstitute.org/))
Identification of why the recipient is receiving the email | "You are receiving this email because you have an account in DUOS" is rendered in every footer

### Example Screenshot
<img width="1032" height="1343" alt="Screenshot 2026-05-22 at 8 42 50 AM" src="https://github.com/user-attachments/assets/529ab18f-6386-4734-a0dd-6b14dde3250e" />

### Fallback Scenario
When there is no group id defined, we fall back to the following:

* A path to DUOS' internal opt-out mechanism
* Physical postal address of the sender
* Identification of why the recipient is receiving the email

<img width="652" height="445" alt="Screenshot 2026-05-22 at 9 04 54 AM" src="https://github.com/user-attachments/assets/671de9b6-7b0c-4486-bb14-631f25a66551" />

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
