### PR TITLE
[DT-3081] Add access type column to new studies digest email

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
@@ -178,6 +178,6 @@ public interface StudyDAO extends Transactional<StudyDAO> {
       WHERE study.study_id IN (<studyIds>)
       GROUP BY study.study_id, study.name
       """)
-  List<StudyDatasetCountRecord> findStudyDatasetCountsWithAccessTypes(
+  List<StudyDatasetCountRecord> findStudyDatasetCounts(
       @BindList(value = "studyIds", onEmpty = EmptyHandling.NULL_STRING) Set<Integer> studyIds);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
@@ -164,11 +164,20 @@ public interface StudyDAO extends Transactional<StudyDAO> {
   @RegisterConstructorMapper(StudyDatasetCountRecord.class)
   @SqlQuery(
       """
-    SELECT study.study_id AS id, study.name, count(dataset.dataset_id) AS dataset_count from study
-        INNER JOIN dataset on study.study_id = dataset.study_id
-    WHERE study.study_id IN (<studyIds>)
-    GROUP BY study.study_id, study.name
-    """)
-  List<StudyDatasetCountRecord> findNameAndDatasetCount(
+      SELECT
+          study.study_id AS id,
+          study.name,
+          string_agg(DISTINCT prop.property_value, ',' ORDER BY prop.property_value) AS access_types,
+          count(DISTINCT dataset.dataset_id) AS dataset_count
+      FROM study
+          INNER JOIN dataset
+              ON study.study_id = dataset.study_id
+          INNER JOIN dataset_property prop
+              ON prop.dataset_id = dataset.dataset_id
+             AND prop.schema_property = 'accessManagement'
+      WHERE study.study_id IN (<studyIds>)
+      GROUP BY study.study_id, study.name
+      """)
+  List<StudyDatasetCountRecord> findStudyDatasetCountsWithAccessTypes(
       @BindList(value = "studyIds", onEmpty = EmptyHandling.NULL_STRING) Set<Integer> studyIds);
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyDatasetCountRecord.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyDatasetCountRecord.java
@@ -1,3 +1,4 @@
 package org.broadinstitute.consent.http.models;
 
-public record StudyDatasetCountRecord(String name, Integer id, Integer datasetCount) {}
+public record StudyDatasetCountRecord(
+    String name, Integer id, String accessTypes, Integer datasetCount) {}

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -213,6 +213,6 @@ public class EmailService implements ConsentLogger {
     Set<Integer> studyIds = new HashSet<>();
     studyIds.addAll(newDacApprovedDatasetStudyIds);
     studyIds.addAll(newOpenOrExternalDatasetStudyIds);
-    return studyDAO.findStudyDatasetCountsWithAccessTypes(studyIds);
+    return studyDAO.findStudyDatasetCounts(studyIds);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -213,6 +213,6 @@ public class EmailService implements ConsentLogger {
     Set<Integer> studyIds = new HashSet<>();
     studyIds.addAll(newDacApprovedDatasetStudyIds);
     studyIds.addAll(newOpenOrExternalDatasetStudyIds);
-    return studyDAO.findNameAndDatasetCount(studyIds);
+    return studyDAO.findStudyDatasetCountsWithAccessTypes(studyIds);
   }
 }

--- a/src/main/resources/freemarker/new-study-digest.ftl
+++ b/src/main/resources/freemarker/new-study-digest.ftl
@@ -13,13 +13,23 @@
         <thead style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
         <tr>
           <th style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">Study Name</th>
-          <th style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">Access Type</th>
+          <th style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">Access Type(s)</th>
           <th style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">Number of Datasets</th>
         </tr>
         </thead>
         <tbody>
       <#list newStudies as item>
-        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;"><a href="${serverUrl}studies/${item.id()?c}">${item.name()}</a></td><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.accessTypes()}</td><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.datasetCount()}</td></tr>
+        <tr>
+          <td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
+            <a href="${serverUrl}studies/${item.id()?c}">${item.name()}</a>
+          </td>
+          <td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
+            <#list item.accessTypes()?split(",") as accessType>${accessType?trim?cap_first}<#sep>, </#list>
+          </td>
+          <td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
+            ${item.datasetCount()}
+          </td>
+        </tr>
       </#list>
         </tbody>
       </table>

--- a/src/main/resources/freemarker/new-study-digest.ftl
+++ b/src/main/resources/freemarker/new-study-digest.ftl
@@ -13,12 +13,13 @@
         <thead style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
         <tr>
           <th style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">Study Name</th>
+          <th style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">Access Type</th>
           <th style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">Number of Datasets</th>
         </tr>
         </thead>
         <tbody>
       <#list newStudies as item>
-        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;"><a href="${serverUrl}studies/${item.id()?c}">${item.name()}</a></td><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.datasetCount()}</td></tr>
+        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;"><a href="${serverUrl}studies/${item.id()?c}">${item.name()}</a></td><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.accessTypes()}</td><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.datasetCount()}</td></tr>
       </#list>
         </tbody>
       </table>

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -10,9 +10,12 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
@@ -21,6 +24,7 @@ import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyDatasetCountRecord;
@@ -380,22 +384,67 @@ class StudyDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindNameAndDatasetCount() {
+  void testFindStudyDatasetCountsWithAccessTypes() {
     Study study1 = insertStudyWithProperties();
     Study study2 = insertStudyWithProperties();
-    IntStream.range(0, 19).forEach(i -> insertDatasetForStudy(study1.getStudyId()));
-    IntStream.range(0, 5).forEach(i -> insertDatasetForStudy(study2.getStudyId()));
+
+    Dataset controlledDataset = insertDatasetForStudy(study1.getStudyId());
+
+    insertAccessManagementDatasetProperty(controlledDataset.getDatasetId(), "controlled");
+
+    Dataset openDataset = insertDatasetForStudy(study1.getStudyId());
+    insertAccessManagementDatasetProperty(openDataset.getDatasetId(), "open");
+
+    Dataset externalDataset = insertDatasetForStudy(study1.getStudyId());
+    insertAccessManagementDatasetProperty(externalDataset.getDatasetId(), "external");
+
+    IntStream.range(0, 16)
+        .forEach(
+            i -> {
+              Dataset dataset = insertDatasetForStudy(study1.getStudyId());
+              insertAccessManagementDatasetProperty(dataset.getDatasetId(), "controlled");
+            });
+
+    IntStream.range(0, 5)
+        .forEach(
+            i -> {
+              Dataset dataset = insertDatasetForStudy(study2.getStudyId());
+              insertAccessManagementDatasetProperty(dataset.getDatasetId(), "open");
+            });
+
     List<StudyDatasetCountRecord> records =
-        studyDAO.findNameAndDatasetCount(Set.of(study1.getStudyId()));
+        studyDAO.findStudyDatasetCountsWithAccessTypes(Set.of(study1.getStudyId()));
+
     assertEquals(1, records.size());
+    assertEquals(study1.getStudyId(), records.getFirst().id());
+    assertEquals(study1.getName(), records.getFirst().name());
+    assertEquals("controlled,external,open", records.getFirst().accessTypes());
     assertEquals(19, records.getFirst().datasetCount());
 
-    records = studyDAO.findNameAndDatasetCount(Set.of(study2.getStudyId()));
+    records = studyDAO.findStudyDatasetCountsWithAccessTypes(Set.of(study2.getStudyId()));
+
     assertEquals(1, records.size());
+    assertEquals(study2.getStudyId(), records.getFirst().id());
+    assertEquals(study2.getName(), records.getFirst().name());
+    assertEquals("open", records.getFirst().accessTypes());
     assertEquals(5, records.getFirst().datasetCount());
 
-    records = studyDAO.findNameAndDatasetCount(Set.of(study1.getStudyId(), study2.getStudyId()));
+    records =
+        studyDAO.findStudyDatasetCountsWithAccessTypes(
+            Set.of(study1.getStudyId(), study2.getStudyId()));
+
     assertEquals(2, records.size());
+
+    Map<Integer, StudyDatasetCountRecord> recordsByStudyId =
+        records.stream()
+            .collect(Collectors.toMap(StudyDatasetCountRecord::id, Function.identity()));
+
+    assertEquals(19, recordsByStudyId.get(study1.getStudyId()).datasetCount());
+    assertEquals(
+        "controlled,external,open", recordsByStudyId.get(study1.getStudyId()).accessTypes());
+
+    assertEquals(5, recordsByStudyId.get(study2.getStudyId()).datasetCount());
+    assertEquals("open", recordsByStudyId.get(study2.getStudyId()).accessTypes());
   }
 
   private FileStorageObject createFileStorageObject(String entityId, FileCategory category) {
@@ -469,5 +518,18 @@ class StudyDAOTest extends DAOTestHelper {
     Integer id =
         datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), null);
     return datasetDAO.findDatasetById(id);
+  }
+
+  private void insertAccessManagementDatasetProperty(Integer datasetId, String propertyValue) {
+    datasetDAO.insertDatasetProperties(
+        List.of(
+            new DatasetProperty(
+                1,
+                datasetId,
+                1,
+                "accessManagement",
+                propertyValue,
+                PropertyType.String,
+                Date.from(Instant.now()))));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -384,7 +384,7 @@ class StudyDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindStudyDatasetCountsWithAccessTypes() {
+  void testFindStudyDatasetCounts() {
     Study study1 = insertStudyWithProperties();
     Study study2 = insertStudyWithProperties();
 
@@ -413,7 +413,7 @@ class StudyDAOTest extends DAOTestHelper {
             });
 
     List<StudyDatasetCountRecord> records =
-        studyDAO.findStudyDatasetCountsWithAccessTypes(Set.of(study1.getStudyId()));
+        studyDAO.findStudyDatasetCounts(Set.of(study1.getStudyId()));
 
     assertEquals(1, records.size());
     assertEquals(study1.getStudyId(), records.getFirst().id());
@@ -421,7 +421,7 @@ class StudyDAOTest extends DAOTestHelper {
     assertEquals("controlled,external,open", records.getFirst().accessTypes());
     assertEquals(19, records.getFirst().datasetCount());
 
-    records = studyDAO.findStudyDatasetCountsWithAccessTypes(Set.of(study2.getStudyId()));
+    records = studyDAO.findStudyDatasetCounts(Set.of(study2.getStudyId()));
 
     assertEquals(1, records.size());
     assertEquals(study2.getStudyId(), records.getFirst().id());
@@ -429,9 +429,7 @@ class StudyDAOTest extends DAOTestHelper {
     assertEquals("open", records.getFirst().accessTypes());
     assertEquals(5, records.getFirst().datasetCount());
 
-    records =
-        studyDAO.findStudyDatasetCountsWithAccessTypes(
-            Set.of(study1.getStudyId(), study2.getStudyId()));
+    records = studyDAO.findStudyDatasetCounts(Set.of(study1.getStudyId(), study2.getStudyId()));
 
     assertEquals(2, records.size());
 

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -437,10 +437,14 @@ class StudyDAOTest extends DAOTestHelper {
         records.stream()
             .collect(Collectors.toMap(StudyDatasetCountRecord::id, Function.identity()));
 
+    // study1 has 3 initial datasets (controlled/open/external) + 16 controlled = 19 total.
+    // The 5 open datasets are created for study2 and are not included here.
     assertEquals(19, recordsByStudyId.get(study1.getStudyId()).datasetCount());
     assertEquals(
         "controlled,external,open", recordsByStudyId.get(study1.getStudyId()).accessTypes());
 
+    // study2 has exactly 5 open datasets created in the second loop.
+    // The initial 3 datasets created for study1 are not included here.
     assertEquals(5, recordsByStudyId.get(study2.getStudyId()).datasetCount());
     assertEquals("open", recordsByStudyId.get(study2.getStudyId()).accessTypes());
   }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,8 +20,8 @@ class NewStudyDigestMessageTest extends AbstractMailMessageTest {
   void testCreateModel_AddsRequiredFields() {
     List<StudyDatasetCountRecord> newStudies =
         List.of(
-            new StudyDatasetCountRecord("My new study", 3, any(), 1),
-            new StudyDatasetCountRecord("My other new study", 4000, any(), 2));
+            new StudyDatasetCountRecord("My new study", 3, "open", 1),
+            new StudyDatasetCountRecord("My other new study", 4000, "controlled", 2));
     User user = new User();
     user.setDisplayName("Test User");
     var message = new NewStudyDigestMessage(user, newStudies, "My reference id");

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
@@ -60,13 +60,13 @@ class NewStudyDigestMessageTest extends AbstractMailMessageTest {
         Objects.requireNonNull(rendered.document().getElementById("userName")).text());
     assertThat(
         rendered.document().body().html(),
-        containsString(
-            urlStringPattern.formatted(
-                serverUrl, record1.id(), record1.name(), record1.accessTypes())));
+        containsString(urlStringPattern.formatted(serverUrl, record1.id(), record1.name())));
     assertThat(
         rendered.document().body().html(),
-        containsString(
-            urlStringPattern.formatted(
-                serverUrl, record2.id(), record2.name(), record2.accessTypes())));
+        containsString(urlStringPattern.formatted(serverUrl, record2.id(), record2.name())));
+
+    // Assert display-formatted access types from template
+    assertThat(rendered.document().body().html(), containsString("Controlled, External"));
+    assertThat(rendered.document().body().html(), containsString("Open"));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,8 +21,8 @@ class NewStudyDigestMessageTest extends AbstractMailMessageTest {
   void testCreateModel_AddsRequiredFields() {
     List<StudyDatasetCountRecord> newStudies =
         List.of(
-            new StudyDatasetCountRecord("My new study", 3, 1),
-            new StudyDatasetCountRecord("My other new study", 4000, 2));
+            new StudyDatasetCountRecord("My new study", 3, any(), 1),
+            new StudyDatasetCountRecord("My other new study", 4000, any(), 2));
     User user = new User();
     user.setDisplayName("Test User");
     var message = new NewStudyDigestMessage(user, newStudies, "My reference id");
@@ -32,8 +33,10 @@ class NewStudyDigestMessageTest extends AbstractMailMessageTest {
   @Test
   void testNewStudyDigestMessage() throws Exception {
     List<StudyDatasetCountRecord> newStudies = new ArrayList<>();
-    StudyDatasetCountRecord record1 = new StudyDatasetCountRecord("My new study", 3, 1);
-    StudyDatasetCountRecord record2 = new StudyDatasetCountRecord("My other new study", 4000, 2);
+    StudyDatasetCountRecord record1 =
+        new StudyDatasetCountRecord("My new study", 3, "controlled, external", 1);
+    StudyDatasetCountRecord record2 =
+        new StudyDatasetCountRecord("My other new study", 4000, "open", 2);
     newStudies.add(record1);
     newStudies.add(record2);
     String referenceId = "My reference id";
@@ -58,9 +61,13 @@ class NewStudyDigestMessageTest extends AbstractMailMessageTest {
         Objects.requireNonNull(rendered.document().getElementById("userName")).text());
     assertThat(
         rendered.document().body().html(),
-        containsString(urlStringPattern.formatted(serverUrl, record1.id(), record1.name())));
+        containsString(
+            urlStringPattern.formatted(
+                serverUrl, record1.id(), record1.name(), record1.accessTypes())));
     assertThat(
         rendered.document().body().html(),
-        containsString(urlStringPattern.formatted(serverUrl, record2.id(), record2.name())));
+        containsString(
+            urlStringPattern.formatted(
+                serverUrl, record2.id(), record2.name(), record2.accessTypes())));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -338,7 +338,7 @@ class EmailServiceTest extends AbstractTestHelper {
   void testSendNewDatasetInDUOSNotifications_No_New_Datasets() {
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any())).thenReturn(List.of());
+    when(studyDAO.findStudyDatasetCounts(any())).thenReturn(List.of());
 
     service.sendNewDatasetInDUOSNotifications();
 
@@ -349,7 +349,7 @@ class EmailServiceTest extends AbstractTestHelper {
   void testSendNewDatasetInDUOSNotifications_Null_Datasets() {
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any())).thenReturn(null);
+    when(studyDAO.findStudyDatasetCounts(any())).thenReturn(null);
 
     service.sendNewDatasetInDUOSNotifications();
 
@@ -365,7 +365,7 @@ class EmailServiceTest extends AbstractTestHelper {
     toUser.setEmailPreference(true);
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any()))
+    when(studyDAO.findStudyDatasetCounts(any()))
         .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, "open", 7)));
     Handle handle = mock(Handle.class);
     Jdbi jdbi = mock(Jdbi.class);
@@ -407,7 +407,7 @@ class EmailServiceTest extends AbstractTestHelper {
     toUser.setEmailPreference(true);
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any()))
+    when(studyDAO.findStudyDatasetCounts(any()))
         .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, "open", 7)));
     Handle handle = mock(Handle.class);
     Jdbi jdbi = mock(Jdbi.class);
@@ -454,7 +454,7 @@ class EmailServiceTest extends AbstractTestHelper {
     toUser.setEmailPreference(true);
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any()))
+    when(studyDAO.findStudyDatasetCounts(any()))
         .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, "open", 7)));
     Handle handle = mock(Handle.class);
     Jdbi jdbi = mock(Jdbi.class);

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -338,7 +338,7 @@ class EmailServiceTest extends AbstractTestHelper {
   void testSendNewDatasetInDUOSNotifications_No_New_Datasets() {
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findNameAndDatasetCount(any())).thenReturn(List.of());
+    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any())).thenReturn(List.of());
 
     service.sendNewDatasetInDUOSNotifications();
 
@@ -349,7 +349,7 @@ class EmailServiceTest extends AbstractTestHelper {
   void testSendNewDatasetInDUOSNotifications_Null_Datasets() {
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findNameAndDatasetCount(any())).thenReturn(null);
+    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any())).thenReturn(null);
 
     service.sendNewDatasetInDUOSNotifications();
 
@@ -365,8 +365,8 @@ class EmailServiceTest extends AbstractTestHelper {
     toUser.setEmailPreference(true);
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findNameAndDatasetCount(any()))
-        .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, 7)));
+    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any()))
+        .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, "open", 7)));
     Handle handle = mock(Handle.class);
     Jdbi jdbi = mock(Jdbi.class);
     when(userDAO.getHandle()).thenReturn(handle);
@@ -407,8 +407,8 @@ class EmailServiceTest extends AbstractTestHelper {
     toUser.setEmailPreference(true);
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findNameAndDatasetCount(any()))
-        .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, 7)));
+    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any()))
+        .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, "open", 7)));
     Handle handle = mock(Handle.class);
     Jdbi jdbi = mock(Jdbi.class);
     when(userDAO.getHandle()).thenReturn(handle);
@@ -454,8 +454,8 @@ class EmailServiceTest extends AbstractTestHelper {
     toUser.setEmailPreference(true);
     when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
     when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
-    when(studyDAO.findNameAndDatasetCount(any()))
-        .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, 7)));
+    when(studyDAO.findStudyDatasetCountsWithAccessTypes(any()))
+        .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, "open", 7)));
     Handle handle = mock(Handle.class);
     Jdbi jdbi = mock(Jdbi.class);
     when(userDAO.getHandle()).thenReturn(handle);

--- a/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
@@ -178,17 +178,16 @@ class FeatureFlagServiceTest extends AbstractTestHelper {
   void testCreateOrUpdateFeatureFlag_Update() {
     Integer userId = 1;
     FeatureFlag updatedFlag = new FeatureFlag("existing-feature", "updated-value");
-
     when(featureFlagDAO.exists("existing-feature")).thenReturn(true);
+    doNothing().when(featureFlagDAO).update(anyString(), anyString());
+    doNothing().when(featureFlagDAO).insertAudit(userId, "existing-feature", "UPDATE");
     when(featureFlagDAO.findById("existing-feature")).thenReturn(updatedFlag);
 
     FeatureFlag result =
         service.createOrUpdateFeatureFlag("existing-feature", "updated-value", userId);
-
     assertNotNull(result);
     assertEquals("existing-feature", result.getId());
     assertEquals("updated-value", result.getValue());
-
     verify(featureFlagDAO).exists("existing-feature");
     verify(featureFlagDAO).update("existing-feature", "updated-value");
     verify(featureFlagDAO).insertAudit(userId, "existing-feature", "UPDATE");

--- a/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
@@ -178,16 +178,17 @@ class FeatureFlagServiceTest extends AbstractTestHelper {
   void testCreateOrUpdateFeatureFlag_Update() {
     Integer userId = 1;
     FeatureFlag updatedFlag = new FeatureFlag("existing-feature", "updated-value");
+
     when(featureFlagDAO.exists("existing-feature")).thenReturn(true);
-    doNothing().when(featureFlagDAO).update(anyString(), anyString());
-    doNothing().when(featureFlagDAO).insertAudit(userId, "existing-feature", "UPDATE");
     when(featureFlagDAO.findById("existing-feature")).thenReturn(updatedFlag);
 
     FeatureFlag result =
         service.createOrUpdateFeatureFlag("existing-feature", "updated-value", userId);
+
     assertNotNull(result);
     assertEquals("existing-feature", result.getId());
     assertEquals("updated-value", result.getValue());
+
     verify(featureFlagDAO).exists("existing-feature");
     verify(featureFlagDAO).update("existing-feature", "updated-value");
     verify(featureFlagDAO).insertAudit(userId, "existing-feature", "UPDATE");


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3081

### Summary

This PR updates the daily new public studies notification to include dataset access management information for each study.

Changes include:

- Adds `accessTypes` to `StudyDatasetCountRecord`
- Updates the study dataset count DAO query to aggregate distinct access management values
- Ensures access types are returned in a consistent sorted order
- Updates tests to verify dataset counts and access type aggregation for public study email data

<img width="1350" height="868" alt="After" src="https://github.com/user-attachments/assets/dee11659-300e-4b39-8ade-727ed2e8a44b" />

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
