### PR TITLE
[DT-3263] Adds requestLocation property.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
@@ -36,6 +36,7 @@ import java.util.Map;
   "dataAccessCommitteeId",
   "dataLocation",
   "url",
+  "requestLocation",
   "numberOfParticipants",
   "fileTypes",
   "data"
@@ -151,6 +152,12 @@ public class ConsentGroup {
   @JsonProperty("url")
   @JsonPropertyDescription("Free text field for entering URL of data")
   private URI url;
+
+  /** URL of an external location where data access requests should be submitted */
+  @JsonProperty("requestLocation")
+  @JsonPropertyDescription(
+      "URL of an external location where data access requests should be submitted")
+  private URI requestLocation;
 
   /** # of Participants (Required) */
   @JsonProperty("numberOfParticipants")
@@ -428,6 +435,18 @@ public class ConsentGroup {
   @JsonProperty("url")
   public void setUrl(URI url) {
     this.url = url;
+  }
+
+  /** URL of an external location where data access requests should be submitted */
+  @JsonProperty("requestLocation")
+  public URI getRequestLocation() {
+    return requestLocation;
+  }
+
+  /** URL of an external location where data access requests should be submitted */
+  @JsonProperty("requestLocation")
+  public void setRequestLocation(URI requestLocation) {
+    this.requestLocation = requestLocation;
   }
 
   /** # of Participants (Required) */

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
@@ -5,6 +5,7 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataLocation;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.fileTypes;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.numberOfParticipants;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.requestLocation;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.url;
 
 import com.google.gson.JsonArray;
@@ -69,6 +70,10 @@ public class ConsentGroupFromDataset {
       if (Objects.nonNull(urlVal)) {
         URI uri = URI.create(urlVal);
         consentGroup.setUrl(uri);
+      }
+      String requestLocationVal = findStringDSPropValue(dataset.getProperties(), requestLocation);
+      if (Objects.nonNull(requestLocationVal)) {
+        consentGroup.setRequestLocation(URI.create(requestLocationVal));
       }
       consentGroup.setNumberOfParticipants(
           findIntegerDSPropValue(dataset.getProperties(), numberOfParticipants));

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
@@ -68,12 +68,13 @@ public class ConsentGroupFromDataset {
       }
       String urlVal = findStringDSPropValue(dataset.getProperties(), url);
       if (Objects.nonNull(urlVal)) {
-        URI uri = URI.create(urlVal);
+        URI uri = createURIWithFallback(urlVal);
         consentGroup.setUrl(uri);
       }
       String requestLocationVal = findStringDSPropValue(dataset.getProperties(), requestLocation);
       if (Objects.nonNull(requestLocationVal)) {
-        consentGroup.setRequestLocation(URI.create(requestLocationVal));
+        URI uri = createURIWithFallback(requestLocationVal);
+        consentGroup.setRequestLocation(uri);
       }
       consentGroup.setNumberOfParticipants(
           findIntegerDSPropValue(dataset.getProperties(), numberOfParticipants));
@@ -85,6 +86,19 @@ public class ConsentGroupFromDataset {
       return consentGroup;
     }
     return null;
+  }
+
+  /**
+   * Safely creates a URI from the given string value. Returns null if URI creation fails, ensuring
+   * that invalid URIs don't break the build process.
+   */
+  private URI createURIWithFallback(String uriString) {
+    try {
+      return URI.create(uriString);
+    } catch (Exception e) {
+      // Return null on failure to avoid breaking the build process
+      return null;
+    }
   }
 
   @Nullable

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
@@ -71,6 +71,7 @@ public class DatasetRegistrationSchemaV1Builder {
   public static final String datasetIdentifier = "datasetIdentifier";
   public static final String dataLocation = "dataLocation";
   public static final String url = "url";
+  public static final String requestLocation = "requestLocation";
   public static final String numberOfParticipants = "numberOfParticipants";
   public static final String fileTypes = "fileTypes";
   public static final String throughBioId = "throughBioId";

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -16,6 +16,7 @@ public class DatasetTerm {
   private DataUseSummary dataUse;
   private String dataLocation;
   private String url;
+  private String requestLocation;
   private Integer dacId;
   private Boolean dacApproval;
   private String accessManagement;
@@ -104,6 +105,14 @@ public class DatasetTerm {
 
   public void setUrl(String url) {
     this.url = url;
+  }
+
+  public String getRequestLocation() {
+    return requestLocation;
+  }
+
+  public void setRequestLocation(String requestLocation) {
+    this.requestLocation = requestLocation;
   }
 
   public Integer getDacId() {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -823,6 +823,16 @@ public class DatasetRegistrationService implements ConsentLogger {
                     return null;
                   }),
               new DatasetPropertyExtractor(
+                  "Request Location",
+                  "requestLocation",
+                  PropertyType.String,
+                  consentGroup -> {
+                    if (Objects.nonNull(consentGroup.getRequestLocation())) {
+                      return consentGroup.getRequestLocation();
+                    }
+                    return null;
+                  }),
+              new DatasetPropertyExtractor(
                   "Access Management",
                   "accessManagement",
                   PropertyType.String,

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -500,6 +500,10 @@ public class ElasticSearchService implements ConsentLogger {
     findDatasetProperty(dataset.getProperties(), "url")
         .ifPresent(datasetProperty -> term.setUrl(datasetProperty.getPropertyValueAsString()));
 
+    findDatasetProperty(dataset.getProperties(), "requestLocation")
+        .ifPresent(
+            datasetProperty -> term.setRequestLocation(datasetProperty.getPropertyValueAsString()));
+
     findDatasetProperty(dataset.getProperties(), "dataLocation")
         .ifPresent(
             datasetProperty -> term.setDataLocation(datasetProperty.getPropertyValueAsString()));

--- a/src/main/resources/assets/paths/datasetV3ById.yaml
+++ b/src/main/resources/assets/paths/datasetV3ById.yaml
@@ -46,6 +46,8 @@ put:
                       propertyValue: Description of Dataset
                     - propertyName: url
                       propertyValue: http://...
+                    - propertyName: requestLocation
+                      propertyValue: https://...
                     - propertyName: Sample Collection ID
                       propertyValue: SC-000
             alternativeDataSharingPlan:

--- a/src/main/resources/assets/paths/datasetV3ById.yaml
+++ b/src/main/resources/assets/paths/datasetV3ById.yaml
@@ -44,9 +44,9 @@ put:
                       propertyValue: 20
                     - propertyName: Description
                       propertyValue: Description of Dataset
-                    - propertyName: url
+                    - propertyName: URL
                       propertyValue: http://...
-                    - propertyName: requestLocation
+                    - propertyName: Request Location
                       propertyValue: https://...
                     - propertyName: Sample Collection ID
                       propertyValue: SC-000

--- a/src/main/resources/assets/schemas/ConsentGroup.yaml
+++ b/src/main/resources/assets/schemas/ConsentGroup.yaml
@@ -84,6 +84,10 @@ properties:
     type: string
     format: uri
     description: Free text field for entering URL of data
+  requestLocation:
+    type: string
+    format: uri
+    description: URL of an external location where data access requests should be submitted
   fileTypes:
     type: array
     items:

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -654,6 +654,13 @@
           "description" : "Free text field for entering URL of data",
           "minLength" : 1
         },
+        "requestLocation" : {
+          "type" : "string",
+          "format" : "uri",
+          "label" : "Request Location URL",
+          "description" : "URL of an external location where data access requests should be submitted",
+          "minLength" : 1
+        },
         "numberOfParticipants" : {
           "type" : "integer",
           "description" : "# of Participants"

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDatasetTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDatasetTest.java
@@ -1,0 +1,165 @@
+package org.broadinstitute.consent.http.models.dataset_registration_v1.builder;
+
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.requestLocation;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.url;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Date;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
+import org.junit.jupiter.api.Test;
+
+class ConsentGroupFromDatasetTest {
+
+  @Test
+  void testBuildReturnsNullWhenDatasetIsNull() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    assertNull(builder.build(null));
+  }
+
+  @Test
+  void testBuildReturnsConsentGroupForEmptyDataset() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = new Dataset();
+    ConsentGroup result = builder.build(dataset);
+    assertNotNull(result);
+  }
+
+  @Test
+  void testBuildWithValidUrl() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = createMockDataset();
+    dataset.addProperty(
+        createDatasetProperty(dataset, url, PropertyType.String, "https://example.com/data"));
+
+    ConsentGroup result = builder.build(dataset);
+
+    assertNotNull(result);
+    assertNotNull(result.getUrl());
+  }
+
+  @Test
+  void testBuildWithMalformedUrlDoesNotThrow() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = createMockDataset();
+    // Spaces in URIs are invalid and cause URI.create() to throw
+    dataset.addProperty(
+        createDatasetProperty(dataset, url, PropertyType.String, "not a valid uri"));
+
+    assertDoesNotThrow(() -> builder.build(dataset));
+  }
+
+  @Test
+  void testBuildWithMalformedUrlSetsNullUrl() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = createMockDataset();
+    dataset.addProperty(
+        createDatasetProperty(dataset, url, PropertyType.String, "not a valid uri"));
+
+    ConsentGroup result = builder.build(dataset);
+
+    assertNotNull(result);
+    assertNull(result.getUrl());
+  }
+
+  @Test
+  void testBuildWithValidRequestLocation() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = createMockDataset();
+    dataset.addProperty(
+        createDatasetProperty(
+            dataset, requestLocation, PropertyType.String, "https://example.com/request"));
+
+    ConsentGroup result = builder.build(dataset);
+
+    assertNotNull(result);
+    assertNotNull(result.getRequestLocation());
+  }
+
+  @Test
+  void testBuildWithMalformedRequestLocationDoesNotThrow() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = createMockDataset();
+    // Spaces in URIs are invalid and cause URI.create() to throw
+    dataset.addProperty(
+        createDatasetProperty(dataset, requestLocation, PropertyType.String, "not a valid uri"));
+
+    assertDoesNotThrow(() -> builder.build(dataset));
+  }
+
+  @Test
+  void testBuildWithMalformedRequestLocationSetsNullRequestLocation() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = createMockDataset();
+    dataset.addProperty(
+        createDatasetProperty(dataset, requestLocation, PropertyType.String, "not a valid uri"));
+
+    ConsentGroup result = builder.build(dataset);
+
+    assertNotNull(result);
+    assertNull(result.getRequestLocation());
+  }
+
+  @Test
+  void testBuildWithBothUrlAndRequestLocation() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = createMockDataset();
+    dataset.addProperty(
+        createDatasetProperty(dataset, url, PropertyType.String, "https://example.com/data"));
+    dataset.addProperty(
+        createDatasetProperty(
+            dataset, requestLocation, PropertyType.String, "https://example.com/request"));
+
+    ConsentGroup result = builder.build(dataset);
+
+    assertNotNull(result);
+    assertNotNull(result.getUrl());
+    assertNotNull(result.getRequestLocation());
+  }
+
+  @Test
+  void testBuildWithBothMalformedUrlAndRequestLocationDoesNotThrow() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = createMockDataset();
+    dataset.addProperty(createDatasetProperty(dataset, url, PropertyType.String, "bad url here"));
+    dataset.addProperty(
+        createDatasetProperty(dataset, requestLocation, PropertyType.String, "bad url here"));
+
+    assertDoesNotThrow(() -> builder.build(dataset));
+  }
+
+  private Dataset createMockDataset() {
+    User user = new User();
+    user.setUserId(RandomUtils.nextInt(1, 1000));
+    user.setDisplayName(RandomStringUtils.randomAlphabetic(10));
+    user.setEmail(RandomStringUtils.randomAlphabetic(5) + "@test.com");
+    Date now = new Date();
+    Dataset dataset = new Dataset();
+    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 1000));
+    dataset.setAlias(RandomUtils.nextInt(1, 1000));
+    dataset.setDatasetIdentifier();
+    dataset.setCreateUser(user);
+    dataset.setCreateUserId(user.getUserId());
+    dataset.setCreateDate(now);
+    return dataset;
+  }
+
+  private DatasetProperty createDatasetProperty(
+      Dataset dataset, String schemaProp, PropertyType type, Object propValue) {
+    DatasetProperty prop = new DatasetProperty();
+    prop.setDatasetId(dataset.getDatasetId());
+    prop.setSchemaProperty(schemaProp);
+    prop.setPropertyName(schemaProp);
+    prop.setPropertyType(type);
+    prop.setPropertyValue(propValue);
+    return prop;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDatasetTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDatasetTest.java
@@ -7,8 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Date;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
@@ -16,7 +15,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
 import org.junit.jupiter.api.Test;
 
-class ConsentGroupFromDatasetTest {
+class ConsentGroupFromDatasetTest extends AbstractTestHelper {
 
   @Test
   void testBuildReturnsNullWhenDatasetIsNull() {
@@ -137,14 +136,14 @@ class ConsentGroupFromDatasetTest {
 
   private Dataset createMockDataset() {
     User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 1000));
-    user.setDisplayName(RandomStringUtils.randomAlphabetic(10));
-    user.setEmail(RandomStringUtils.randomAlphabetic(5) + "@test.com");
+    user.setUserId(randomInt(1, 1000));
+    user.setDisplayName(randomAlphabetic(10));
+    user.setEmail(randomAlphabetic(5) + "@test.com");
     Date now = new Date();
     Dataset dataset = new Dataset();
-    dataset.setName(RandomStringUtils.randomAlphabetic(10));
-    dataset.setDatasetId(RandomUtils.nextInt(1, 1000));
-    dataset.setAlias(RandomUtils.nextInt(1, 1000));
+    dataset.setName(randomAlphabetic(10));
+    dataset.setDatasetId(randomInt(1, 1000));
+    dataset.setAlias(randomInt(1, 1000));
     dataset.setDatasetIdentifier();
     dataset.setCreateUser(user);
     dataset.setCreateUserId(user.getUserId());

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -853,6 +853,59 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testConvertConsentGroupToDatasetProperties_RequestLocation() throws Exception {
+    User user = mock();
+    DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
+    ConsentGroup consentGroup = schema.getConsentGroups().getFirst();
+    consentGroup.setRequestLocation(URI.create("https://request.example.org/apply"));
+
+    when(dacDAO.findById(any())).thenReturn(new Dac());
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setStudyId(123);
+    when(datasetDAO.findDatasetsByIdList(any())).thenReturn(List.of(dataset));
+
+    datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
+
+    verify(datasetServiceDAO)
+        .insertDatasetRegistration(studyInsert.capture(), datasetInsertCaptor.capture());
+
+    List<DatasetServiceDAO.DatasetInsert> inserts = datasetInsertCaptor.getValue();
+    List<DatasetProperty> props = inserts.getFirst().props();
+    assertTrue(
+        props.stream()
+            .anyMatch(
+                p ->
+                    p.getSchemaProperty().equals("requestLocation")
+                        && p.getPropertyValue()
+                            .toString()
+                            .equals("https://request.example.org/apply")));
+  }
+
+  @Test
+  void testConvertConsentGroupToDatasetProperties_NoRequestLocation() throws Exception {
+    User user = mock();
+    DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
+    ConsentGroup consentGroup = schema.getConsentGroups().getFirst();
+    // requestLocation intentionally not set
+
+    when(dacDAO.findById(any())).thenReturn(new Dac());
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setStudyId(123);
+    when(datasetDAO.findDatasetsByIdList(any())).thenReturn(List.of(dataset));
+
+    datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
+
+    verify(datasetServiceDAO)
+        .insertDatasetRegistration(studyInsert.capture(), datasetInsertCaptor.capture());
+
+    List<DatasetServiceDAO.DatasetInsert> inserts = datasetInsertCaptor.getValue();
+    List<DatasetProperty> props = inserts.getFirst().props();
+    assertTrue(props.stream().noneMatch(p -> p.getSchemaProperty().equals("requestLocation")));
+  }
+
+  @Test
   void cleanupEmptyDatasetNihInstitutionalCertificationFile() {
     User user = new User();
     user.setUserId(1);

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -885,9 +885,8 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
   @Test
   void testConvertConsentGroupToDatasetProperties_NoRequestLocation() throws Exception {
     User user = mock();
-    DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
-    ConsentGroup consentGroup = schema.getConsentGroups().getFirst();
-    // requestLocation intentionally not set
+    DatasetRegistrationSchemaV1 schema =
+        createRandomMinimumDatasetRegistration(user); // requestLocation intentionally not set
 
     when(dacDAO.findById(any())).thenReturn(new Dac());
     Dataset dataset = new Dataset();

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -554,6 +554,44 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testToDatasetTerm_RequestLocation() {
+    User user = createUser(1, 100);
+    User updateUser = createUser(101, 200);
+    Dac dac = createDac();
+    Study study = createStudy(user);
+    Dataset dataset = createDataset(user, updateUser, new DataUse(), dac);
+    dataset.setProperties(
+        Set.of(createDatasetProperty("requestLocation", PropertyType.String, "Request Location")));
+    dataset.setStudy(study);
+    when(userDao.findUserById(user.getUserId())).thenReturn(user);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    Optional<DatasetProperty> requestLocationProp =
+        dataset.getProperties().stream()
+            .filter(p -> p.getSchemaProperty().equals("requestLocation"))
+            .findFirst();
+    assertTrue(requestLocationProp.isPresent());
+    assertEquals(
+        requestLocationProp.get().getPropertyValue().toString(), term.getRequestLocation());
+  }
+
+  @Test
+  void testToDatasetTerm_RequestLocation_Missing() {
+    User user = createUser(1, 100);
+    User updateUser = createUser(101, 200);
+    Dac dac = createDac();
+    Dataset dataset = createDataset(user, updateUser, new DataUse(), dac);
+    // No requestLocation property
+    dataset.setProperties(Set.of(createDatasetProperty("url", PropertyType.String, "url")));
+    when(userDao.findUserById(user.getUserId())).thenReturn(user);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertNull(term.getRequestLocation());
+  }
+
+  @Test
   void testToDatasetTermNullDatasetProps() {
     Dataset dataset = new Dataset();
     assertDoesNotThrow(() -> service.toDatasetTerm(dataset));


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3263](https://broadworkbench.atlassian.net/browse/DT-3263)

### Summary

Updates consent groups so they can contain a property for storing the location where users should visit to fill out data access requests.  Ensures the property is indexed into ElasticSearch when added.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
