### PR TITLE
[DT-3132] Fix NPE in DatasetPatch when properties is null 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
@@ -25,6 +25,9 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
     if (name() != null && !name().equals(dataset.getName()) && !name().isBlank()) {
       return true;
     }
+    if (properties() == null) {
+      return false;
+    }
     // Find any cases where the new property value is different from the existing one
     return properties().stream()
         .anyMatch(
@@ -58,6 +61,12 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
   }
 
   public boolean validateProperties() {
+    if (properties == null) {
+      return false;
+    }
+    if (properties.isEmpty()) {
+      return true;
+    }
     // The following properties are patch-able:
     Map<String, Function<Object, Boolean>> validators =
         Map.of(

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetPatchTest.java
@@ -48,6 +48,26 @@ public class DatasetPatchTest {
   }
 
   @Test
+  void testIsPatchableNullProps() {
+    Dataset dataset = new Dataset();
+    dataset.setName(RandomStringUtils.insecure().nextAlphabetic(10));
+    DatasetPatch patch = new DatasetPatch(null, null);
+    assertFalse(patch.isPatchable(dataset));
+  }
+
+  @Test
+  void testValidatePropertiesNullProps() {
+    DatasetPatch patch = new DatasetPatch(null, null);
+    assertFalse(patch.validateProperties());
+  }
+
+  @Test
+  void testValidatePropertiesEmptyProps() {
+    DatasetPatch patch = new DatasetPatch(null, List.of());
+    assertTrue(patch.validateProperties());
+  }
+
+  @Test
   void testInvalidPropertyKeys() {
     DatasetProperty invalidProp = new DatasetProperty();
     invalidProp.setPropertyName(RandomStringUtils.randomAlphanumeric(25));

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -352,6 +352,26 @@ class DatasetResourceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testPatchByDatasetUpdate_nullProperties() {
+    Gson gson = GsonUtil.buildGson();
+
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(randomInt(1, 100));
+    dataset.setName(randomAlphabetic(10));
+    dataset.setCreateUserId(user.getUserId());
+    when(datasetService.findDatasetById(any(), any())).thenReturn(dataset);
+
+    // Gson omits null fields, so this serializes to {"name":"..."} with no properties key,
+    // which deserializes back to a DatasetPatch with null properties.
+    DatasetPatch patch = new DatasetPatch(randomAlphabetic(20), null);
+
+    try (Response response =
+        resource.patchByDatasetUpdate(duosUser, dataset.getDatasetId(), gson.toJson(patch))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
+
+  @Test
   void testValidateDatasetNameSuccess() {
     Dataset testDataset = new Dataset();
     when(datasetService.getDatasetByName("test")).thenReturn(testDataset);


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3132

### Summary

 `validateProperties()` threw a `NullPointerException` when a PATCH request was sent without a `properties` field, because Gson deserializes the missing field as `null` and the method called `properties.stream()`         
  directly.                                                                                                                                                                                                         
                                                                                                                                                                                                                    
  Changes:                                                                                                                                                                                                          
  - `validateProperties()` — returns `false` for null properties, rejecting the request with a `400` before reaching the DAO layer                                                                                        
  - `isPatchable()` — guards against null properties to avoid a second latent NPE                                                                                                                                     
  - `DatasetPatchTest` — adds tests for null and empty properties on both methods                                                                                                                                     
  - `DatasetResourceTest` — adds an end-to-end test confirming a null-properties PATCH returns `400`    

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
