### PR TITLE
[DT-3066] Drop `datarequest` and `researchpurpose` tables  

### DIFF
--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -249,4 +249,5 @@
   <include file="changesets/changelog-consent-2026-04-08-dar-daa.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-04-28-dar-dataset-daa-snapshot.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-06-02-study-pi-email.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-06-11-drop-datarequest-researchpurpose.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-06-11-drop-datarequest-researchpurpose.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-06-11-drop-datarequest-researchpurpose.xml
@@ -1,0 +1,10 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2026-06-11-drop-datarequest" author="kmarete">
+    <dropTable tableName="datarequest" cascadeConstraints="true"/>
+  </changeSet>
+  <changeSet id="changelog-consent-2026-06-11-drop-researchpurpose" author="kmarete">
+    <dropTable tableName="researchpurpose" cascadeConstraints="true"/>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3066

### Summary

The `datarequest` and `researchpurpose` tables are legacy tables with no data in production and no references in application code. This PR removes them via two separate Liquibase changesets — `datarequest` is dropped first to respect its foreign key dependency on `researchpurpose`.  

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
