### PR TITLE
[DT-3602] fix auto open

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -7,7 +7,6 @@ import static org.broadinstitute.consent.http.resources.Resource.CHAIRPERSON;
 import static org.broadinstitute.consent.http.resources.Resource.MEMBER;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Streams;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import freemarker.template.TemplateException;
@@ -19,13 +18,13 @@ import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -865,7 +864,7 @@ public class DarCollectionService implements ConsentLogger {
     }
 
     // Create elections and votes for auto-open DACs
-    createElectionsAndVotesForAutoOpenDacs(context.classification, context.latestDar);
+    createElectionsAndVotesForAutoOpenDacs(context.classification(), context.latestDar());
   }
 
   /** Sends notification messages for a new DAR collection. */
@@ -875,34 +874,34 @@ public class DarCollectionService implements ConsentLogger {
     if (context == null) {
       return;
     }
-    if (!context.latestDar.getRequiresSOApproval()
-        || context.latestDar.getApprovingSigningOfficialUserId() != null) {
+    if (!context.latestDar().getRequiresSOApproval()
+        || context.latestDar().getApprovingSigningOfficialUserId() != null) {
       // Notify users for auto-open DACs
       notifyUsersForDacs(
-          context.classification.autoOpenUsers,
-          context.classification.autoOpenDacs,
-          context.classification.autoOpenDatasets,
-          context.latestDar,
-          context.darCollection,
-          context.researcherName,
+          context.classification().autoOpenUsers,
+          context.classification().autoOpenDacs,
+          context.classification().autoOpenDatasets,
+          context.latestDar(),
+          context.darCollection(),
+          context.researcherName(),
           true);
 
       // Notify users for manual DACs
       notifyUsersForDacs(
-          context.classification.manualOpenUsers,
-          context.classification.manualOpenDacs,
-          context.classification.manualOpenDatasets,
-          context.latestDar,
-          context.darCollection,
-          context.researcherName,
+          context.classification().manualOpenUsers,
+          context.classification().manualOpenDacs,
+          context.classification().manualOpenDatasets,
+          context.latestDar(),
+          context.darCollection(),
+          context.researcherName(),
           false);
     } else {
-      notifySpecificSigningOfficialOfApprovalNeeded(context.latestDar, context.researcher);
+      notifySpecificSigningOfficialOfApprovalNeeded(context.latestDar(), context.researcher());
     }
 
     // Notify signing officials of DAR submission
     notifySigningOfficialsOfDARSubmission(
-        context.latestDar, context.researcher, context.darCollection.getDarCode());
+        context.latestDar(), context.researcher(), context.darCollection().getDarCode());
   }
 
   /** Helper method to retrieve the DAR collection context for processing. */
@@ -916,7 +915,7 @@ public class DarCollectionService implements ConsentLogger {
 
     // Get the most recent DAR and its associated users
     DataAccessRequest latestDar = darCollection.getMostRecentDar();
-    List<User> adminAndChairUsers = getDistinctAdminAndChairUsersForDAR(latestDar);
+    List<User> dacUsers = getDacUsersForDAR(latestDar);
 
     // Get researcher details
     User researcher = userDAO.findUserById(darCollection.getCreateUserId());
@@ -929,15 +928,16 @@ public class DarCollectionService implements ConsentLogger {
 
     // Classify DACs and users by automation rules
     DacUserClassification classification =
-        classifyDacsAndUsers(dacsForDar, datasetsForDar, adminAndChairUsers);
+        classifyDacsAndUsers(dacsForDar, datasetsForDar, dacUsers);
 
     return new DarCollectionContext(
         darCollection, latestDar, researcher, researcherName, classification);
   }
 
   /** Classifies DACs and users based on automation rules. */
-  private DacUserClassification classifyDacsAndUsers(
-      Collection<Dac> dacsForDar, List<Dataset> datasetsForDar, List<User> adminAndChairUsers) {
+  @VisibleForTesting
+  protected DacUserClassification classifyDacsAndUsers(
+      Collection<Dac> dacsForDar, List<Dataset> datasetsForDar, List<User> dacUsers) {
 
     Set<Integer> dacIds =
         datasetsForDar.stream().map(Dataset::getDacId).collect(Collectors.toSet());
@@ -945,97 +945,63 @@ public class DarCollectionService implements ConsentLogger {
     DacUserClassification result = new DacUserClassification();
 
     for (Integer dacId : dacIds) {
-      List<DACAutomationRule> dacRules = dacAutomationRuleService.findAllByDacId(dacId);
-      boolean autoOpen = hasAutoOpenRule(dacRules);
-      Integer autoOpenUserId = getAutoOpenRuleEnabledByUserId(dacId);
+      Optional<DACAutomationRule> autoOpenRule =
+          dacAutomationRuleService.findAllByDacId(dacId).stream()
+              .filter(
+                  r ->
+                      r.ruleType() == DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS
+                          && r.enabledByUserId() != null)
+              .findFirst();
 
-      Dac dac = findDac(dacsForDar, dacId);
-      List<Dataset> datasetsForDac = findAllDatasetsForDac(datasetsForDar, dacId);
-      if (autoOpen) {
-        addAutoOpen(result, dacId, autoOpenUserId, dac, datasetsForDac);
-        addUsers(result.autoOpenUsers, dacId, adminAndChairUsers, true);
+      Dac dac =
+          dacsForDar.stream().filter(d -> d.getDacId().equals(dacId)).findFirst().orElse(null);
+      List<Dataset> datasetsForDac =
+          datasetsForDar.stream().filter(ds -> ds.getDacId().equals(dacId)).toList();
+
+      if (autoOpenRule.isPresent()) {
+        if (dac != null) {
+          result.autoOpenDacs.add(dac);
+        }
+        result.autoOpenDatasets.addAll(datasetsForDac);
+        result.autoOpenUserIds.put(dacId, autoOpenRule.get().enabledByUserId());
+        addUsers(result.autoOpenUsers, dacId, dacUsers, true);
       } else {
-        addManualOpen(result, dac, datasetsForDac);
-        addUsers(result.manualOpenUsers, dacId, adminAndChairUsers, false);
+        if (dac != null) {
+          result.manualOpenDacs.add(dac);
+        }
+        result.manualOpenDatasets.addAll(datasetsForDac);
+        addUsers(result.manualOpenUsers, dacId, dacUsers, false);
       }
     }
 
     return result;
   }
 
-  /** Finds a DAC by its ID from a collection of DACs. */
-  private Dac findDac(Collection<Dac> dacs, Integer dacId) {
-    return dacs.stream().filter(d -> d.getDacId().equals(dacId)).findFirst().orElse(null);
-  }
-
-  /** Finds all datasets belonging to the given DAC ID from a list of datasets. */
-  private List<Dataset> findAllDatasetsForDac(List<Dataset> datasets, Integer dacId) {
-    return datasets.stream().filter(ds -> ds.getDacId().equals(dacId)).toList();
-  }
-
-  /** Checks if an auto-open rule exists for a given DAC ID. */
-  private boolean hasAutoOpenRule(List<DACAutomationRule> dacRules) {
-    return dacRules.stream()
-        .anyMatch(
-            r ->
-                r.ruleType() == DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS
-                    && r.enabledByUserId() != null);
-  }
-
-  /** Retrieves the user ID associated with the auto-open rule for a given DAC ID. */
-  private Integer getAutoOpenRuleEnabledByUserId(Integer dacId) {
-    return dacAutomationRuleService.findAllByDacId(dacId).stream()
-        .filter(
-            r ->
-                r.ruleType() == DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS
-                    && r.enabledByUserId() != null)
-        .map(DACAutomationRule::enabledByUserId)
-        .findFirst()
-        .orElse(null);
-  }
-
-  /** Adds DACs, datasets, and auto-open user IDs to the auto open classification. */
-  private void addAutoOpen(
-      DacUserClassification result,
-      Integer dacId,
-      Integer autoOpenUserId,
-      Dac dac,
-      List<Dataset> datasets) {
-
-    if (dac != null) {
-      result.autoOpenDacs.add(dac);
-    }
-    result.autoOpenDatasets.addAll(datasets);
-    result.autoOpenUserIds.put(dacId, autoOpenUserId);
-  }
-
-  /** Adds DACs and datasets to the manual open classification. */
-  private void addManualOpen(DacUserClassification result, Dac dac, List<Dataset> datasets) {
-
-    if (dac != null) {
-      result.manualOpenDacs.add(dac);
-    }
-    result.manualOpenDatasets.addAll(datasets);
-  }
-
   /** Adds users to the target set based on their DAC roles and the autoOpen flag. */
-  private void addUsers(Set<User> targetSet, Integer dacId, List<User> users, boolean autoOpen) {
+  @VisibleForTesting
+  protected void addUsers(Set<User> targetSet, Integer dacId, List<User> users, boolean autoOpen) {
 
     for (User user : users) {
       boolean isChair = user.verifyDACRole(CHAIRPERSON, dacId);
       boolean isMember = user.verifyDACRole(MEMBER, dacId);
-      boolean isAdmin = user.hasUserRole(ADMIN);
-
       if (autoOpen) {
         if (isChair || isMember) {
           targetSet.add(user);
         }
       } else { // manual
-        if (isChair || isAdmin) {
+        if (isChair) {
           targetSet.add(user);
         }
       }
     }
+  }
+
+  /** Returns users from the set that hold a CHAIRPERSON or MEMBER role for the given DAC. */
+  @VisibleForTesting
+  protected Set<User> filterUsersForDac(Set<User> allUsers, Integer dacId) {
+    return allUsers.stream()
+        .filter(u -> u.verifyDACRole(CHAIRPERSON, dacId) || u.verifyDACRole(MEMBER, dacId))
+        .collect(Collectors.toSet());
   }
 
   /** Creates elections and votes for DACs with auto-open rules. */
@@ -1060,12 +1026,9 @@ public class DarCollectionService implements ConsentLogger {
             int rpElectionId =
                 dacAutomationRuleService.createOpenElectionForDAR(latestDar, dataset, RP);
 
-            createVotesForAllUsers(
-                classification.autoOpenUsers,
-                dataAccessElectionId,
-                rpElectionId,
-                latestDar,
-                dataset.getDacId());
+            Integer dacId = dataset.getDacId();
+            Set<User> dacUsers = filterUsersForDac(classification.autoOpenUsers, dacId);
+            createVotesForAllUsers(dacUsers, dataAccessElectionId, rpElectionId, latestDar, dacId);
 
             return null;
           });
@@ -1161,7 +1124,13 @@ public class DarCollectionService implements ConsentLogger {
                 dar.getReferenceId()));
   }
 
-  /** Notifies users for the given DACs and datasets. */
+  /**
+   * Notifies users for the given DACs and datasets.
+   *
+   * <p>When {@code isAutoOpen} is {@code true}, each user receives a single auto-open email; {@code
+   * dacs} and {@code datasets} are not consulted. When {@code false}, per-user DAC/dataset
+   * membership is resolved from {@code dacs} and {@code datasets} to build the email body.
+   */
   @VisibleForTesting
   protected void notifyUsersForDacs(
       Set<User> users,
@@ -1172,13 +1141,7 @@ public class DarCollectionService implements ConsentLogger {
       String researcherName,
       boolean isAutoOpen)
       throws IOException, TemplateException {
-    Map<String, List<String>> dacToDatasetsMap = new HashMap<>();
     for (User user : users) {
-      List<Dac> userDacs = getMatchingDacs(user, dacs);
-      for (Dac dac : userDacs) {
-        List<String> datasetIdentifiers = getMatchingDatasets(dac, new ArrayList<>(datasets));
-        dacToDatasetsMap.put(dac.getName(), datasetIdentifiers);
-      }
       if (isAutoOpen) {
         // Send election notification for auto-open DACs
         if (latestDar.getProgressReport()) {
@@ -1188,6 +1151,12 @@ public class DarCollectionService implements ConsentLogger {
         }
       } else {
         // Send manual notification for manual DACs
+        Map<String, List<String>> dacToDatasetsMap = new HashMap<>();
+        List<Dac> userDacs = getMatchingDacs(user, dacs);
+        for (Dac dac : userDacs) {
+          List<String> datasetIdentifiers = getMatchingDatasets(dac, new ArrayList<>(datasets));
+          dacToDatasetsMap.put(dac.getName(), datasetIdentifiers);
+        }
         if (latestDar.getProgressReport()) {
           sendNewProgressReportRequestEmail(
               user,
@@ -1330,24 +1299,17 @@ public class DarCollectionService implements ConsentLogger {
     }
   }
 
-  private List<User> getDistinctAdminAndChairUsersForDAR(DataAccessRequest dar) {
-    List<Integer> datasetIds = dar.getDatasetIds();
-    return getDistinctAdminAndChairUsersForDatasetIds(datasetIds);
+  private List<User> getDacUsersForDAR(DataAccessRequest dar) {
+    return getDacUsersForDatasetIds(dar.getDatasetIds());
   }
 
-  private List<User> getDistinctAdminAndChairUsersForDatasetIds(List<Integer> datasetIds) {
-    List<User> admins = userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId());
-    Set<User> chairPersons =
+  private List<User> getDacUsersForDatasetIds(List<Integer> datasetIds) {
+    return new ArrayList<>(
         userDAO.findUsersForDatasetsByRole(
-            datasetIds, Collections.singletonList(UserRoles.CHAIRPERSON.getRoleId()));
-    // Ensure that admins/chairs are not double emailed
-    return Streams.concat(admins.stream(), chairPersons.stream()).distinct().toList();
+            datasetIds, List.of(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.MEMBER.getRoleId())));
   }
 
   private List<Dac> getMatchingDacs(User user, Collection<Dac> dacsInDAR) {
-    if (user.hasUserRole(UserRoles.ADMIN)) {
-      return new ArrayList<>(dacsInDAR);
-    }
     List<Integer> dacIDs =
         user.getRoles().stream().map(UserRole::getDacId).filter(Objects::nonNull).toList();
     return dacsInDAR.stream().filter(dac -> dacIDs.contains(dac.getDacId())).toList();
@@ -1360,27 +1322,12 @@ public class DarCollectionService implements ConsentLogger {
         .toList();
   }
 
-  /** Helper class to hold context for processing a DAR collection. */
-  private static class DarCollectionContext {
-    final DarCollection darCollection;
-    final DataAccessRequest latestDar;
-    final User researcher;
-    final String researcherName;
-    final DacUserClassification classification;
-
-    DarCollectionContext(
-        DarCollection darCollection,
-        DataAccessRequest latestDar,
-        User researcher,
-        String researcherName,
-        DacUserClassification classification) {
-      this.darCollection = darCollection;
-      this.latestDar = latestDar;
-      this.researcher = researcher;
-      this.researcherName = researcherName;
-      this.classification = classification;
-    }
-  }
+  private record DarCollectionContext(
+      DarCollection darCollection,
+      DataAccessRequest latestDar,
+      User researcher,
+      String researcherName,
+      DacUserClassification classification) {}
 
   /** Helper class to hold classification results for DACs, users, and datasets. */
   @VisibleForTesting

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -874,34 +874,40 @@ public class DarCollectionService implements ConsentLogger {
     if (context == null) {
       return;
     }
-    if (!context.latestDar().getRequiresSOApproval()
-        || context.latestDar().getApprovingSigningOfficialUserId() != null) {
+
+    DataAccessRequest latestDar = context.latestDar();
+    DacUserClassification classification = context.classification();
+    DarCollection darCollection = context.darCollection();
+    String researcherName = context.researcherName();
+    User researcher = context.researcher();
+
+    if (!latestDar.getRequiresSOApproval()
+        || latestDar.getApprovingSigningOfficialUserId() != null) {
       // Notify users for auto-open DACs
       notifyUsersForDacs(
-          context.classification().autoOpenUsers,
-          context.classification().autoOpenDacs,
-          context.classification().autoOpenDatasets,
-          context.latestDar(),
-          context.darCollection(),
-          context.researcherName(),
+          classification.autoOpenUsers,
+          classification.autoOpenDacs,
+          classification.autoOpenDatasets,
+          latestDar,
+          darCollection,
+          researcherName,
           true);
 
       // Notify users for manual DACs
       notifyUsersForDacs(
-          context.classification().manualOpenUsers,
-          context.classification().manualOpenDacs,
-          context.classification().manualOpenDatasets,
-          context.latestDar(),
-          context.darCollection(),
-          context.researcherName(),
+          classification.manualOpenUsers,
+          classification.manualOpenDacs,
+          classification.manualOpenDatasets,
+          latestDar,
+          darCollection,
+          researcherName,
           false);
     } else {
-      notifySpecificSigningOfficialOfApprovalNeeded(context.latestDar(), context.researcher());
+      notifySpecificSigningOfficialOfApprovalNeeded(latestDar, researcher);
     }
 
     // Notify signing officials of DAR submission
-    notifySigningOfficialsOfDARSubmission(
-        context.latestDar(), context.researcher(), context.darCollection().getDarCode());
+    notifySigningOfficialsOfDARSubmission(latestDar, researcher, darCollection.getDarCode());
   }
 
   /** Helper method to retrieve the DAR collection context for processing. */

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -953,22 +953,17 @@ public class DarCollectionService implements ConsentLogger {
                           && r.enabledByUserId() != null)
               .findFirst();
 
-      Dac dac =
-          dacsForDar.stream().filter(d -> d.getDacId().equals(dacId)).findFirst().orElse(null);
+      Optional<Dac> dac = dacsForDar.stream().filter(d -> d.getDacId().equals(dacId)).findFirst();
       List<Dataset> datasetsForDac =
           datasetsForDar.stream().filter(ds -> ds.getDacId().equals(dacId)).toList();
 
       if (autoOpenRule.isPresent()) {
-        if (dac != null) {
-          result.autoOpenDacs.add(dac);
-        }
+        dac.ifPresent(result.autoOpenDacs::add);
         result.autoOpenDatasets.addAll(datasetsForDac);
         result.autoOpenUserIds.put(dacId, autoOpenRule.get().enabledByUserId());
         addUsers(result.autoOpenUsers, dacId, dacUsers, true);
       } else {
-        if (dac != null) {
-          result.manualOpenDacs.add(dac);
-        }
+        dac.ifPresent(result.manualOpenDacs::add);
         result.manualOpenDatasets.addAll(datasetsForDac);
         addUsers(result.manualOpenUsers, dacId, dacUsers, false);
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -950,13 +950,12 @@ public class DarCollectionService implements ConsentLogger {
       Integer autoOpenUserId = getAutoOpenRuleEnabledByUserId(dacId);
 
       Dac dac = findDac(dacsForDar, dacId);
-      Dataset dataset = findDataset(datasetsForDar, dacId);
-      // If the DAC requires SO approval the submission is not a progress report
+      List<Dataset> datasetsForDac = findAllDatasetsForDac(datasetsForDar, dacId);
       if (autoOpen) {
-        addAutoOpen(result, dacId, autoOpenUserId, dac, dataset);
+        addAutoOpen(result, dacId, autoOpenUserId, dac, datasetsForDac);
         addUsers(result.autoOpenUsers, dacId, adminAndChairUsers, true);
       } else {
-        addManualOpen(result, dac, dataset);
+        addManualOpen(result, dac, datasetsForDac);
         addUsers(result.manualOpenUsers, dacId, adminAndChairUsers, false);
       }
     }
@@ -969,9 +968,9 @@ public class DarCollectionService implements ConsentLogger {
     return dacs.stream().filter(d -> d.getDacId().equals(dacId)).findFirst().orElse(null);
   }
 
-  /** Finds a dataset by its DAC ID from a list of datasets. */
-  private Dataset findDataset(List<Dataset> datasets, Integer dacId) {
-    return datasets.stream().filter(ds -> ds.getDacId().equals(dacId)).findFirst().orElse(null);
+  /** Finds all datasets belonging to the given DAC ID from a list of datasets. */
+  private List<Dataset> findAllDatasetsForDac(List<Dataset> datasets, Integer dacId) {
+    return datasets.stream().filter(ds -> ds.getDacId().equals(dacId)).toList();
   }
 
   /** Checks if an auto-open rule exists for a given DAC ID. */
@@ -1001,26 +1000,22 @@ public class DarCollectionService implements ConsentLogger {
       Integer dacId,
       Integer autoOpenUserId,
       Dac dac,
-      Dataset dataset) {
+      List<Dataset> datasets) {
 
     if (dac != null) {
       result.autoOpenDacs.add(dac);
     }
-    if (dataset != null) {
-      result.autoOpenDatasets.add(dataset);
-    }
+    result.autoOpenDatasets.addAll(datasets);
     result.autoOpenUserIds.put(dacId, autoOpenUserId);
   }
 
   /** Adds DACs and datasets to the manual open classification. */
-  private void addManualOpen(DacUserClassification result, Dac dac, Dataset dataset) {
+  private void addManualOpen(DacUserClassification result, Dac dac, List<Dataset> datasets) {
 
     if (dac != null) {
       result.manualOpenDacs.add(dac);
     }
-    if (dataset != null) {
-      result.manualOpenDatasets.add(dataset);
-    }
+    result.manualOpenDatasets.addAll(datasets);
   }
 
   /** Adds users to the target set based on their DAC roles and the autoOpen flag. */
@@ -1032,7 +1027,7 @@ public class DarCollectionService implements ConsentLogger {
       boolean isAdmin = user.hasUserRole(ADMIN);
 
       if (autoOpen) {
-        if (isChair || isMember || isAdmin) {
+        if (isChair || isMember) {
           targetSet.add(user);
         }
       } else { // manual
@@ -1066,7 +1061,11 @@ public class DarCollectionService implements ConsentLogger {
                 dacAutomationRuleService.createOpenElectionForDAR(latestDar, dataset, RP);
 
             createVotesForAllUsers(
-                classification.autoOpenUsers, dataAccessElectionId, rpElectionId, latestDar);
+                classification.autoOpenUsers,
+                dataAccessElectionId,
+                rpElectionId,
+                latestDar,
+                dataset.getDacId());
 
             return null;
           });
@@ -1102,12 +1101,16 @@ public class DarCollectionService implements ConsentLogger {
   /** Creates standard votes for all users for the given elections. */
   @VisibleForTesting
   protected void createVotesForAllUsers(
-      Set<User> users, int dataAccessElectionId, int rpElectionId, DataAccessRequest dar) {
+      Set<User> users,
+      int dataAccessElectionId,
+      int rpElectionId,
+      DataAccessRequest dar,
+      Integer dacId) {
 
     for (User user : users) {
       createStandardVotes(dataAccessElectionId, rpElectionId, user);
 
-      if (user.hasUserRole(UserRoles.CHAIRPERSON)) {
+      if (user.verifyDACRole(CHAIRPERSON, dacId)) {
         createChairpersonVotes(dataAccessElectionId, rpElectionId, user, dar);
       }
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -2965,7 +2965,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setData(new DataAccessRequestData());
 
-    service.createVotesForAllUsers(Set.of(), 1, 2, dar);
+    service.createVotesForAllUsers(Set.of(), 1, 2, dar, 1);
 
     verifyNoInteractions(dacAutomationRuleService);
   }
@@ -2976,7 +2976,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setData(new DataAccessRequestData());
 
-    service.createVotesForAllUsers(Set.of(member), 10, 20, dar);
+    service.createVotesForAllUsers(Set.of(member), 10, 20, dar, 1);
 
     verify(dacAutomationRuleService).createVoteForElection(10, member.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService).createVoteForElection(20, member.getUserId(), VoteType.DAC);
@@ -2985,11 +2985,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
   @Test
   void testCreateVotesForAllUsers_ChairpersonNoManualReview() {
-    User chair = createUserWithRole(UserRoles.CHAIRPERSON);
+    int dacId = 1;
+    User chair = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, dacId);
     DataAccessRequest dar = new DataAccessRequest();
     dar.setData(new DataAccessRequestData()); // all flags null → requiresManualReview() == false
 
-    service.createVotesForAllUsers(Set.of(chair), 10, 20, dar);
+    service.createVotesForAllUsers(Set.of(chair), 10, 20, dar, dacId);
 
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService).createVoteForElection(20, chair.getUserId(), VoteType.DAC);
@@ -3005,13 +3006,14 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
   @Test
   void testCreateVotesForAllUsers_ChairpersonRequiresManualReview() {
-    User chair = createUserWithRole(UserRoles.CHAIRPERSON);
+    int dacId = 1;
+    User chair = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, dacId);
     DataAccessRequest dar = new DataAccessRequest();
     DataAccessRequestData data = new DataAccessRequestData();
     data.setPoa(true); // triggers requiresManualReview() == true
     dar.setData(data);
 
-    service.createVotesForAllUsers(Set.of(chair), 10, 20, dar);
+    service.createVotesForAllUsers(Set.of(chair), 10, 20, dar, dacId);
 
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService).createVoteForElection(20, chair.getUserId(), VoteType.DAC);
@@ -3026,12 +3028,13 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
   @Test
   void testCreateVotesForAllUsers_MixedChairAndMember() {
-    User chair = createUserWithRole(UserRoles.CHAIRPERSON);
+    int dacId = 1;
+    User chair = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, dacId);
     User member = createUserWithRole(UserRoles.MEMBER);
     DataAccessRequest dar = new DataAccessRequest();
     dar.setData(new DataAccessRequestData());
 
-    service.createVotesForAllUsers(Set.of(chair, member), 10, 20, dar);
+    service.createVotesForAllUsers(Set.of(chair, member), 10, 20, dar, dacId);
 
     // chair gets DAC + CHAIRPERSON + FINAL + AGREEMENT votes
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.DAC);
@@ -3047,6 +3050,475 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService).createVoteForElection(10, member.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService).createVoteForElection(20, member.getUserId(), VoteType.DAC);
     verifyNoMoreInteractions(dacAutomationRuleService);
+  }
+
+  @Test
+  void testCreateVotesForAllUsers_AdminUserGetsOnlyDacVotesNotChairpersonVotes() {
+    // Admins are passed through but should never receive chairperson votes since they have no
+    // dacId-scoped CHAIRPERSON role
+    User admin = createUserWithRole(UserRoles.ADMIN);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setData(new DataAccessRequestData());
+
+    service.createVotesForAllUsers(Set.of(admin), 10, 20, dar, 1);
+
+    verify(dacAutomationRuleService).createVoteForElection(10, admin.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService).createVoteForElection(20, admin.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(anyInt(), eq(admin.getUserId()), eq(VoteType.CHAIRPERSON));
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(anyInt(), eq(admin.getUserId()), eq(VoteType.FINAL));
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(anyInt(), eq(admin.getUserId()), eq(VoteType.AGREEMENT));
+    verifyNoMoreInteractions(dacAutomationRuleService);
+  }
+
+  @Test
+  void testCreateVotesForAllUsers_ChairOfDifferentDacGetsNochairpersonVotes() {
+    // A chair from DAC 2 should not receive chairperson votes when creating votes for DAC 1's
+    // election
+    int electionDacId = 1;
+    User chairOfOtherDac = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 2);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setData(new DataAccessRequestData());
+
+    service.createVotesForAllUsers(Set.of(chairOfOtherDac), 10, 20, dar, electionDacId);
+
+    verify(dacAutomationRuleService)
+        .createVoteForElection(10, chairOfOtherDac.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(20, chairOfOtherDac.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(anyInt(), eq(chairOfOtherDac.getUserId()), eq(VoteType.CHAIRPERSON));
+    verifyNoMoreInteractions(dacAutomationRuleService);
+  }
+
+  @Test
+  void testCreateElectionsAndVotesForAutoOpenDacs_MultipleDatasetsSameDac() {
+    // Both datasets from the same DAC must each get their own elections
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setData(new DataAccessRequestData());
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(10);
+
+    DacUserClassification classification = new DacUserClassification();
+    classification.autoOpenDatasets.add(dataset1);
+    classification.autoOpenDatasets.add(dataset2);
+
+    when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
+        .thenReturn(null);
+    when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), any(), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), any(), eq(ElectionType.RP)))
+        .thenReturn(200);
+    stubInTransactionToExecute();
+
+    service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
+
+    verify(dacAutomationRuleService)
+        .createOpenElectionForDAR(dar, dataset1, ElectionType.DATA_ACCESS);
+    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset1, ElectionType.RP);
+    verify(dacAutomationRuleService)
+        .createOpenElectionForDAR(dar, dataset2, ElectionType.DATA_ACCESS);
+    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset2, ElectionType.RP);
+  }
+
+  // ─── Multi-DAC / autoOpen on+off comprehensive vote coverage ──────────────
+
+  /**
+   * autoOpen ON, two datasets in different DACs, chairs and members are distinct per DAC.
+   *
+   * <p>Verifies that for each dataset's elections:
+   *
+   * <ul>
+   *   <li>The chair of that specific DAC gets DAC + CHAIRPERSON + FINAL + AGREEMENT votes
+   *   <li>The member of that specific DAC gets only DAC votes
+   *   <li>Users from the OTHER DAC get only standard DAC votes (no CHAIRPERSON/FINAL/AGREEMENT)
+   * </ul>
+   */
+  @Test
+  void testElectionVotes_AutoOpenOn_TwoDacs_DistinctChairsAndMembers() {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setData(new DataAccessRequestData()); // requiresManualReview() == false
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+
+    User chairDac10 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User memberDac10 = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+    User chairDac20 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+    User memberDac20 = createUserWithRoleAndDacId(UserRoles.MEMBER, 20);
+
+    DacUserClassification classification = new DacUserClassification();
+    classification.autoOpenDatasets.add(dataset1);
+    classification.autoOpenDatasets.add(dataset2);
+    classification.autoOpenUsers.addAll(Set.of(chairDac10, memberDac10, chairDac20, memberDac20));
+
+    when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
+        .thenReturn(null);
+    when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
+    // dataset1: DATA_ACCESS=100, RP=200; dataset2: DATA_ACCESS=300, RP=400
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.RP)))
+        .thenReturn(200);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.RP)))
+        .thenReturn(400);
+    stubInTransactionToExecute();
+
+    service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
+
+    // ── dataset1 (DAC 10) elections ──────────────────────────────────────────
+    // chairDac10 gets full chair votes for DATA_ACCESS election 100 and RP election 200
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, chairDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, chairDac10.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.AGREEMENT);
+    // memberDac10 gets only DAC votes
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, memberDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, memberDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(eq(100), eq(memberDac10.getUserId()), eq(VoteType.CHAIRPERSON));
+    // chairDac20 gets only standard DAC votes for DAC 10's elections (not a chair of DAC 10)
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, chairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(eq(100), eq(chairDac20.getUserId()), eq(VoteType.CHAIRPERSON));
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(eq(100), eq(chairDac20.getUserId()), eq(VoteType.FINAL));
+    // memberDac20 gets only standard DAC votes for DAC 10's elections
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, memberDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, memberDac20.getUserId(), VoteType.DAC);
+
+    // ── dataset2 (DAC 20) elections ──────────────────────────────────────────
+    // chairDac20 gets full chair votes
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, chairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac20.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, chairDac20.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac20.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac20.getUserId(), VoteType.AGREEMENT);
+    // memberDac20 gets only DAC votes
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, memberDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(eq(300), eq(memberDac20.getUserId()), eq(VoteType.CHAIRPERSON));
+    // chairDac10 gets only standard DAC votes for DAC 20's elections (not a chair of DAC 20)
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, chairDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(eq(300), eq(chairDac10.getUserId()), eq(VoteType.CHAIRPERSON));
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(eq(300), eq(chairDac10.getUserId()), eq(VoteType.FINAL));
+    // memberDac10 gets only standard DAC votes for DAC 20's elections
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, memberDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, memberDac10.getUserId(), VoteType.DAC);
+  }
+
+  /**
+   * autoOpen ON, two datasets in different DACs, one user chairs both DACs.
+   *
+   * <p>Verifies that the shared chair receives full CHAIRPERSON + FINAL + AGREEMENT votes for both
+   * DAC 10's and DAC 20's elections (because they have CHAIRPERSON role for each).
+   */
+  @Test
+  void testElectionVotes_AutoOpenOn_TwoDacs_SameUserChairsBothDacs() {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setData(new DataAccessRequestData());
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+
+    // sharedChair has CHAIRPERSON role for both DAC 10 and DAC 20
+    User sharedChair = new User();
+    sharedChair.setUserId(randomInt(1, 100000));
+    sharedChair.setEmailPreference(Boolean.TRUE);
+    UserRole roleForDac10 =
+        new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    roleForDac10.setDacId(10);
+    UserRole roleForDac20 =
+        new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    roleForDac20.setDacId(20);
+    sharedChair.setRoles(List.of(roleForDac10, roleForDac20));
+
+    DacUserClassification classification = new DacUserClassification();
+    classification.autoOpenDatasets.add(dataset1);
+    classification.autoOpenDatasets.add(dataset2);
+    classification.autoOpenUsers.add(sharedChair);
+
+    when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
+        .thenReturn(null);
+    when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.RP)))
+        .thenReturn(200);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.RP)))
+        .thenReturn(400);
+    stubInTransactionToExecute();
+
+    service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
+
+    // sharedChair gets full chair votes for dataset1 (DAC 10)
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedChair.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, sharedChair.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedChair.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, sharedChair.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedChair.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedChair.getUserId(), VoteType.AGREEMENT);
+    // sharedChair also gets full chair votes for dataset2 (DAC 20)
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, sharedChair.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, sharedChair.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, sharedChair.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, sharedChair.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, sharedChair.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, sharedChair.getUserId(), VoteType.AGREEMENT);
+  }
+
+  /**
+   * autoOpen ON, two datasets in different DACs, same user is chair of DAC 10 and member of DAC 20.
+   *
+   * <p>Verifies that the shared user gets:
+   *
+   * <ul>
+   *   <li>Full CHAIRPERSON + FINAL + AGREEMENT votes for DAC 10's elections
+   *   <li>Only standard DAC votes for DAC 20's elections (member role, not chair)
+   * </ul>
+   */
+  @Test
+  void testElectionVotes_AutoOpenOn_TwoDacs_SameUserChairOfOneAndMemberOfOther() {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setData(new DataAccessRequestData());
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+
+    // sharedUser: CHAIRPERSON of DAC 10, MEMBER of DAC 20
+    User sharedUser = new User();
+    sharedUser.setUserId(randomInt(1, 100000));
+    sharedUser.setEmailPreference(Boolean.TRUE);
+    UserRole chairRoleDac10 =
+        new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    chairRoleDac10.setDacId(10);
+    UserRole memberRoleDac20 =
+        new UserRole(UserRoles.MEMBER.getRoleId(), UserRoles.MEMBER.getRoleName());
+    memberRoleDac20.setDacId(20);
+    sharedUser.setRoles(List.of(chairRoleDac10, memberRoleDac20));
+
+    // separateChair is the chair of DAC 20
+    User separateChairDac20 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+
+    DacUserClassification classification = new DacUserClassification();
+    classification.autoOpenDatasets.add(dataset1);
+    classification.autoOpenDatasets.add(dataset2);
+    classification.autoOpenUsers.add(sharedUser);
+    classification.autoOpenUsers.add(separateChairDac20);
+
+    when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
+        .thenReturn(null);
+    when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.RP)))
+        .thenReturn(200);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.RP)))
+        .thenReturn(400);
+    stubInTransactionToExecute();
+
+    service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
+
+    // ── dataset1 (DAC 10) ─────────────────────────────────────────────────────
+    // sharedUser is chair of DAC 10 → full chair votes
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedUser.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, sharedUser.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedUser.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, sharedUser.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedUser.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedUser.getUserId(), VoteType.AGREEMENT);
+    // separateChairDac20 is not chair of DAC 10 → only DAC votes for dataset1
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, separateChairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, separateChairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(
+            eq(100), eq(separateChairDac20.getUserId()), eq(VoteType.CHAIRPERSON));
+
+    // ── dataset2 (DAC 20) ─────────────────────────────────────────────────────
+    // sharedUser is member of DAC 20, not chair → only DAC votes
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, sharedUser.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, sharedUser.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(eq(300), eq(sharedUser.getUserId()), eq(VoteType.CHAIRPERSON));
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(eq(300), eq(sharedUser.getUserId()), eq(VoteType.FINAL));
+    // separateChairDac20 is chair of DAC 20 → full chair votes
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, separateChairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, separateChairDac20.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.AGREEMENT);
+  }
+
+  /**
+   * autoOpen OFF, two datasets in different DACs with distinct chairs.
+   *
+   * <p>Verifies that when no DAC has an auto-open rule, no elections and no votes are created via
+   * the automation path.
+   */
+  @Test
+  void testElectionVotes_AutoOpenOff_TwoDacs_NoElectionsOrVotesCreated() throws Exception {
+    DarCollection collection = new DarCollection();
+    collection.setDarCollectionId(1);
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setDatasetIds(List.of(dataset1.getDatasetId(), dataset2.getDatasetId()));
+    collection.addDar(dar);
+
+    Dac dac10 = new Dac();
+    dac10.setDacId(10);
+    dac10.setName("DAC-10");
+
+    Dac dac20 = new Dac();
+    dac20.setDacId(20);
+    dac20.setName("DAC-20");
+
+    User chairDac10 = new User();
+    chairDac10.setUserId(randomInt(1, 100000));
+    UserRole chair10Role =
+        new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    chair10Role.setDacId(10);
+    chairDac10.setRoles(List.of(chair10Role));
+
+    User chairDac20 = new User();
+    chairDac20.setUserId(randomInt(1, 100000));
+    UserRole chair20Role =
+        new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    chair20Role.setDacId(20);
+    chairDac20.setRoles(List.of(chair20Role));
+
+    when(darCollectionDAO.findDARCollectionByCollectionId(1)).thenReturn(collection);
+    when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset1, dataset2));
+    when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac10, dac20));
+    // No auto-open rule for either DAC
+    when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of());
+    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
+    when(userDAO.findUsersForDatasetsByRole(anyList(), anyList()))
+        .thenReturn(Set.of(chairDac10, chairDac20));
+    when(userDAO.findUserById(any())).thenReturn(new User());
+
+    service.createElectionsForNewDarCollection(1);
+
+    // No elections or votes created when auto-open is off
+    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), any(), any());
+    verify(dacAutomationRuleService, never()).createVoteForElection(anyInt(), anyInt(), any());
   }
 
   @Test
@@ -3184,6 +3656,18 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     user.setDisplayName(String.format("%s - %s", userRoles.getRoleName(), user.getUserId()));
     user.setEmail(String.format("%s@test.com", userRoles.getRoleName()));
     UserRole role = new UserRole(userRoles.getRoleId(), userRoles.getRoleName());
+    user.setRoles(List.of(role));
+    user.setEmailPreference(Boolean.TRUE);
+    return user;
+  }
+
+  private User createUserWithRoleAndDacId(UserRoles userRoles, Integer dacId) {
+    User user = new User();
+    user.setUserId(randomInt(1, 100000));
+    user.setDisplayName(String.format("%s - %s", userRoles.getRoleName(), user.getUserId()));
+    user.setEmail(String.format("%s@test.com", userRoles.getRoleName()));
+    UserRole role = new UserRole(userRoles.getRoleId(), userRoles.getRoleName());
+    role.setDacId(dacId);
     user.setRoles(List.of(role));
     user.setEmailPreference(Boolean.TRUE);
     return user;

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -4290,7 +4290,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
   @Test
   void testClassifyDacsAndUsers_DatasetWithNoMatchingDac_DacNotAddedToResult() {
-    // dataset references dacId=10, but no Dac object with id=10 is in dacsForDar
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
     dataset.setDacId(10);
@@ -4305,9 +4304,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DacUserClassification result =
         service.classifyDacsAndUsers(List.of(), List.of(dataset), List.of(chair));
 
-    // DAC object is absent (null guard in classifyDacsAndUsers prevents adding null)
     assertTrue(result.autoOpenDacs.isEmpty());
-    // Dataset, users, and userIds are still classified despite the missing DAC object
     assertTrue(result.autoOpenDatasets.contains(dataset));
     assertTrue(result.autoOpenUsers.contains(chair));
     assertEquals(chair.getUserId(), result.autoOpenUserIds.get(10));

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -3015,8 +3015,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(20, chair.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.FINAL);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(10, chair.getUserId(), VoteType.AGREEMENT);
+    // Exactly 5 vote-creation calls: AGREEMENT is not created when requiresManualReview is true.
+    verify(dacAutomationRuleService, times(5)).createVoteForElection(anyInt(), anyInt(), any());
   }
 
   @Test
@@ -3060,8 +3060,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(10, chairOfOtherDac.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(20, chairOfOtherDac.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(anyInt(), eq(chairOfOtherDac.getUserId()), eq(VoteType.CHAIRPERSON));
     verifyNoMoreInteractions(dacAutomationRuleService);
   }
 
@@ -3189,12 +3187,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(100, memberDac10.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(200, memberDac10.getUserId(), VoteType.DAC);
-    // DAC 20 users must not appear in DAC 10's elections
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(100, chairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(100, memberDac20.getUserId(), VoteType.DAC);
-
     // DAC 20 election — only chairDac20 and memberDac20
     verify(dacAutomationRuleService)
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.DAC);
@@ -3210,11 +3202,9 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(400, memberDac20.getUserId(), VoteType.DAC);
-    // DAC 10 users must not appear in DAC 20's elections
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(300, chairDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(300, memberDac10.getUserId(), VoteType.DAC);
+
+    // Exactly 16 vote-creation calls: cross-DAC users received no votes in the wrong elections.
+    verify(dacAutomationRuleService, times(16)).createVoteForElection(anyInt(), anyInt(), any());
   }
 
   /**
@@ -3444,8 +3434,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
-    // ── dataset1 (DAC 10) elections ──────────────────────────────────────────
-    // chairDac10 gets full chair votes for DATA_ACCESS election 100 and RP election 200
+    // ── dataset1 (DAC 10): chairDac10 gets full chair votes; memberDac10 gets DAC votes only ──
     verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
@@ -3458,29 +3447,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.AGREEMENT);
-    // memberDac10 gets only DAC votes
     verify(dacAutomationRuleService)
         .createVoteForElection(100, memberDac10.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(200, memberDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(100, memberDac10.getUserId(), VoteType.CHAIRPERSON);
-    // chairDac20 and memberDac20 are not members of DAC 10 → no votes in DAC 10's elections
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(100, chairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(200, chairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(100, chairDac20.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(100, chairDac20.getUserId(), VoteType.FINAL);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(100, memberDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(200, memberDac20.getUserId(), VoteType.DAC);
 
-    // ── dataset2 (DAC 20) elections ──────────────────────────────────────────
-    // chairDac20 gets full chair votes
+    // ── dataset2 (DAC 20): chairDac20 gets full chair votes; memberDac20 gets DAC votes only ──
     verify(dacAutomationRuleService)
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
@@ -3493,26 +3465,14 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.AGREEMENT);
-    // memberDac20 gets only DAC votes
     verify(dacAutomationRuleService)
         .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(400, memberDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(300, memberDac20.getUserId(), VoteType.CHAIRPERSON);
-    // chairDac10 and memberDac10 are not members of DAC 20 → no votes in DAC 20's elections
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(300, chairDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(400, chairDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(300, chairDac10.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(300, chairDac10.getUserId(), VoteType.FINAL);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(300, memberDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(400, memberDac10.getUserId(), VoteType.DAC);
+
+    // Exactly 16 vote-creation calls: cross-DAC users and member CHAIRPERSON votes are excluded.
+    // Any cross-DAC contamination or spurious role promotion would push this count above 16.
+    verify(dacAutomationRuleService, times(16)).createVoteForElection(anyInt(), anyInt(), any());
   }
 
   /**
@@ -3677,24 +3637,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(100, sharedUser.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, sharedUser.getUserId(), VoteType.AGREEMENT);
-    // separateChairDac20 is not a member of DAC 10 → no votes for dataset1's elections
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(100, separateChairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(200, separateChairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(100, separateChairDac20.getUserId(), VoteType.CHAIRPERSON);
-
     // ── dataset2 (DAC 20) ─────────────────────────────────────────────────────
     // sharedUser is member of DAC 20, not chair → only DAC votes
     verify(dacAutomationRuleService)
         .createVoteForElection(300, sharedUser.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(400, sharedUser.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(300, sharedUser.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(300, sharedUser.getUserId(), VoteType.FINAL);
     // separateChairDac20 is chair of DAC 20 → full chair votes
     verify(dacAutomationRuleService)
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.DAC);
@@ -3708,6 +3656,11 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.AGREEMENT);
+
+    // Exactly 14 vote-creation calls: cross-DAC isolation and the sharedUser's member (not chair)
+    // role in DAC 20 are both enforced — any leakage or spurious promotion pushes the count above
+    // 14.
+    verify(dacAutomationRuleService, times(14)).createVoteForElection(anyInt(), anyInt(), any());
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -87,6 +87,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -2165,7 +2166,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset));
     when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac));
     when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of());
-    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
     when(userDAO.findUsersForDatasetsByRole(anyList(), anyList())).thenReturn(Set.of(chair));
     service.createElectionsForNewDarCollection(1);
     service.sendNewDARCollectionMessage(1);
@@ -2210,7 +2210,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset));
     when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac));
     when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of(rule));
-    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
     when(userDAO.findUsersForDatasetsByRole(anyList(), anyList())).thenReturn(Set.of(member));
     when(userDAO.findUserById(any())).thenReturn(new User());
 
@@ -2265,7 +2264,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset));
     when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac));
     when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of(rule));
-    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
     when(userDAO.findUsersForDatasetsByRole(anyList(), anyList())).thenReturn(Set.of(member));
     when(userDAO.findUserById(any())).thenReturn(new User());
 
@@ -2322,7 +2320,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset));
     when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac));
     when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of(rule));
-    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
     when(userDAO.findUsersForDatasetsByRole(anyList(), anyList())).thenReturn(Set.of(member));
     when(userDAO.findUserById(any())).thenReturn(new User());
     when(userDAO.findUserByEmail(signingOfficial.getEmail())).thenReturn(signingOfficial);
@@ -2380,7 +2377,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset));
     when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac));
     when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of(rule));
-    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
     when(userDAO.findUsersForDatasetsByRole(anyList(), anyList())).thenReturn(Set.of(member));
     when(userDAO.findUserById(any())).thenReturn(new User());
 
@@ -2440,7 +2436,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset));
     when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac));
     when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of(rule));
-    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
     when(userDAO.findUsersForDatasetsByRole(anyList(), anyList())).thenReturn(Set.of(chairperson));
     when(userDAO.findUserById(any())).thenReturn(new User());
 
@@ -2506,7 +2501,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(autoOpenDac, manualDac));
     when(dacAutomationRuleService.findAllByDacId(autoOpenDac.getDacId())).thenReturn(List.of(rule));
     when(dacAutomationRuleService.findAllByDacId(manualDac.getDacId())).thenReturn(List.of());
-    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
     when(userDAO.findUsersForDatasetsByRole(anyList(), anyList()))
         .thenReturn(Set.of(member, chair));
     when(userDAO.findUserById(any())).thenReturn(new User());
@@ -2612,7 +2606,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(List.of(disabledAutoOpenRule, disabledRequireSORule));
     when(dacAutomationRuleService.findAllByDacId(soRequiredDac.getDacId()))
         .thenReturn(List.of(enabledRequireSORule));
-    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
     when(userDAO.findUsersForDatasetsByRole(anyList(), anyList()))
         .thenReturn(Set.of(member, chair));
     when(userDAO.findUserById(any())).thenReturn(new User());
@@ -2885,7 +2878,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     dataset.setDatasetId(1);
     dataset.setDacId(10);
 
-    User member = createUserWithRole(UserRoles.MEMBER);
+    User member = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
 
     DacUserClassification classification = new DacUserClassification();
     classification.autoOpenDatasets.add(dataset);
@@ -3053,27 +3046,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testCreateVotesForAllUsers_AdminUserGetsOnlyDacVotesNotChairpersonVotes() {
-    // Admins are passed through but should never receive chairperson votes since they have no
-    // dacId-scoped CHAIRPERSON role
-    User admin = createUserWithRole(UserRoles.ADMIN);
-    DataAccessRequest dar = new DataAccessRequest();
-    dar.setData(new DataAccessRequestData());
-
-    service.createVotesForAllUsers(Set.of(admin), 10, 20, dar, 1);
-
-    verify(dacAutomationRuleService).createVoteForElection(10, admin.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService).createVoteForElection(20, admin.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(anyInt(), eq(admin.getUserId()), eq(VoteType.CHAIRPERSON));
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(anyInt(), eq(admin.getUserId()), eq(VoteType.FINAL));
-    verify(dacAutomationRuleService, never())
-        .createVoteForElection(anyInt(), eq(admin.getUserId()), eq(VoteType.AGREEMENT));
-    verifyNoMoreInteractions(dacAutomationRuleService);
-  }
-
-  @Test
   void testCreateVotesForAllUsers_ChairOfDifferentDacGetsNochairpersonVotes() {
     // A chair from DAC 2 should not receive chairperson votes when creating votes for DAC 1's
     // election
@@ -3130,6 +3102,289 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createOpenElectionForDAR(dar, dataset2, ElectionType.DATA_ACCESS);
     verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset2, ElectionType.RP);
+  }
+
+  // ─── Full-flow integration: userDAO → classifyDacsAndUsers → vote creation ──
+
+  /**
+   * Full flow — two auto-open DACs, distinct chairs and members.
+   *
+   * <p>Exercises the complete path from userDAO sourcing through classifyDacsAndUsers into vote
+   * creation. Verifies that cross-DAC isolation holds end-to-end: each user receives votes only for
+   * the election belonging to their own DAC.
+   */
+  @Test
+  void testFullFlow_TwoAutoOpenDacs_DistinctChairsAndMembers_VotesCreatedPerDac() {
+    User chairDac10 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User memberDac10 = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+    User chairDac20 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+    User memberDac20 = createUserWithRoleAndDacId(UserRoles.MEMBER, 20);
+
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setData(new DataAccessRequestData());
+    dar.setDatasetIds(List.of(1, 2));
+
+    DarCollection collection = new DarCollection();
+    collection.setDarCollectionId(1);
+    collection.setCreateUserId(99);
+    collection.addDar(dar);
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+
+    Dac dac10 = new Dac();
+    dac10.setDacId(10);
+    Dac dac20 = new Dac();
+    dac20.setDacId(20);
+
+    DACAutomationRule autoOpenRule = mock(DACAutomationRule.class);
+    when(autoOpenRule.ruleType()).thenReturn(DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS);
+    when(autoOpenRule.enabledByUserId()).thenReturn(chairDac10.getUserId());
+
+    when(darCollectionDAO.findDARCollectionByCollectionId(1)).thenReturn(collection);
+    when(userDAO.findUserById(99)).thenReturn(new User());
+    when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset1, dataset2));
+    when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac10, dac20));
+    when(userDAO.findUsersForDatasetsByRole(anyList(), anyList()))
+        .thenReturn(Set.of(chairDac10, memberDac10, chairDac20, memberDac20));
+    when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of(autoOpenRule));
+    when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
+        .thenReturn(null);
+    when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.RP)))
+        .thenReturn(200);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.RP)))
+        .thenReturn(400);
+    stubInTransactionToExecute();
+
+    service.createElectionsForNewDarCollection(1);
+
+    // DAC 10 election — only chairDac10 and memberDac10
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, chairDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.AGREEMENT);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, memberDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(200, memberDac10.getUserId(), VoteType.DAC);
+    // DAC 20 users must not appear in DAC 10's elections
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(100, chairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(100, memberDac20.getUserId(), VoteType.DAC);
+
+    // DAC 20 election — only chairDac20 and memberDac20
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, chairDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac20.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac20.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac20.getUserId(), VoteType.AGREEMENT);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(400, memberDac20.getUserId(), VoteType.DAC);
+    // DAC 10 users must not appear in DAC 20's elections
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(300, chairDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(300, memberDac10.getUserId(), VoteType.DAC);
+  }
+
+  /**
+   * Full flow — one auto-open DAC, one manual DAC.
+   *
+   * <p>Verifies that classification correctly routes users from the two DACs into separate sets,
+   * and that only the auto-open DAC's datasets receive elections and votes.
+   */
+  @Test
+  void testFullFlow_MixedDacs_OnlyAutoOpenDacReceivesElectionsAndVotes() {
+    User chairDac10 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User memberDac10 = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+    User chairDac20 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setData(new DataAccessRequestData());
+    dar.setDatasetIds(List.of(1, 2));
+
+    DarCollection collection = new DarCollection();
+    collection.setDarCollectionId(1);
+    collection.setCreateUserId(99);
+    collection.addDar(dar);
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+
+    Dac dac10 = new Dac();
+    dac10.setDacId(10);
+    Dac dac20 = new Dac();
+    dac20.setDacId(20);
+
+    DACAutomationRule autoOpenRule = mock(DACAutomationRule.class);
+    when(autoOpenRule.ruleType()).thenReturn(DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS);
+    when(autoOpenRule.enabledByUserId()).thenReturn(chairDac10.getUserId());
+
+    when(darCollectionDAO.findDARCollectionByCollectionId(1)).thenReturn(collection);
+    when(userDAO.findUserById(99)).thenReturn(new User());
+    when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset1, dataset2));
+    when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac10, dac20));
+    when(userDAO.findUsersForDatasetsByRole(anyList(), anyList()))
+        .thenReturn(Set.of(chairDac10, memberDac10, chairDac20));
+    when(dacAutomationRuleService.findAllByDacId(10)).thenReturn(List.of(autoOpenRule));
+    when(dacAutomationRuleService.findAllByDacId(20)).thenReturn(List.of());
+    when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
+        .thenReturn(null);
+    when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.RP)))
+        .thenReturn(200);
+    stubInTransactionToExecute();
+
+    service.createElectionsForNewDarCollection(1);
+
+    // DAC 10 auto-open → elections and votes created
+    verify(dacAutomationRuleService)
+        .createOpenElectionForDAR(dar, dataset1, ElectionType.DATA_ACCESS);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac10.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, memberDac10.getUserId(), VoteType.DAC);
+
+    // DAC 20 manual → no election created, no votes for chairDac20
+    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), eq(dataset2), any());
+    verify(dacAutomationRuleService, never())
+        .createVoteForElection(anyInt(), eq(chairDac20.getUserId()), any());
+  }
+
+  /**
+   * Full flow — user chairs both auto-open DACs.
+   *
+   * <p>Verifies that a user deduped in the flat autoOpenUsers set (Set semantics via addUsers)
+   * still receives full chairperson votes for both elections because the per-DAC filter in
+   * createElectionsAndVotesForAutoOpenDacs matches them for each DAC independently.
+   */
+  @Test
+  void testFullFlow_UserChairsBothAutoOpenDacs_GetsFullVotesInBothElections() {
+    // sharedChair has CHAIRPERSON role for both DAC 10 and DAC 20
+    User sharedChair = new User();
+    sharedChair.setUserId(randomInt(1, 100000));
+    sharedChair.setEmailPreference(true);
+    UserRole roleForDac10 =
+        new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    roleForDac10.setDacId(10);
+    UserRole roleForDac20 =
+        new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    roleForDac20.setDacId(20);
+    sharedChair.setRoles(List.of(roleForDac10, roleForDac20));
+
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setData(new DataAccessRequestData());
+    dar.setDatasetIds(List.of(1, 2));
+
+    DarCollection collection = new DarCollection();
+    collection.setDarCollectionId(1);
+    collection.setCreateUserId(99);
+    collection.addDar(dar);
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+
+    Dac dac10 = new Dac();
+    dac10.setDacId(10);
+    Dac dac20 = new Dac();
+    dac20.setDacId(20);
+
+    DACAutomationRule autoOpenRule = mock(DACAutomationRule.class);
+    when(autoOpenRule.ruleType()).thenReturn(DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS);
+    when(autoOpenRule.enabledByUserId()).thenReturn(sharedChair.getUserId());
+
+    when(darCollectionDAO.findDARCollectionByCollectionId(1)).thenReturn(collection);
+    when(userDAO.findUserById(99)).thenReturn(new User());
+    when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset1, dataset2));
+    when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac10, dac20));
+    when(userDAO.findUsersForDatasetsByRole(anyList(), anyList())).thenReturn(Set.of(sharedChair));
+    when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of(autoOpenRule));
+    when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
+        .thenReturn(null);
+    when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset1), eq(ElectionType.RP)))
+        .thenReturn(200);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(
+            any(), eq(dataset2), eq(ElectionType.RP)))
+        .thenReturn(400);
+    stubInTransactionToExecute();
+
+    service.createElectionsForNewDarCollection(1);
+
+    // Full chair votes in both DAC 10's and DAC 20's elections
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedChair.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedChair.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedChair.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(100, sharedChair.getUserId(), VoteType.AGREEMENT);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, sharedChair.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, sharedChair.getUserId(), VoteType.CHAIRPERSON);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, sharedChair.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService)
+        .createVoteForElection(300, sharedChair.getUserId(), VoteType.AGREEMENT);
   }
 
   // ─── Multi-DAC / autoOpen on+off comprehensive vote coverage ──────────────
@@ -3209,20 +3464,19 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(200, memberDac10.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService, never())
-        .createVoteForElection(eq(100), eq(memberDac10.getUserId()), eq(VoteType.CHAIRPERSON));
-    // chairDac20 gets only standard DAC votes for DAC 10's elections (not a chair of DAC 10)
-    verify(dacAutomationRuleService)
+        .createVoteForElection(100, memberDac10.getUserId(), VoteType.CHAIRPERSON);
+    // chairDac20 and memberDac20 are not members of DAC 10 → no votes in DAC 10's elections
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(100, chairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(200, chairDac20.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService, never())
-        .createVoteForElection(eq(100), eq(chairDac20.getUserId()), eq(VoteType.CHAIRPERSON));
+        .createVoteForElection(100, chairDac20.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService, never())
-        .createVoteForElection(eq(100), eq(chairDac20.getUserId()), eq(VoteType.FINAL));
-    // memberDac20 gets only standard DAC votes for DAC 10's elections
-    verify(dacAutomationRuleService)
+        .createVoteForElection(100, chairDac20.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(100, memberDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(200, memberDac20.getUserId(), VoteType.DAC);
 
     // ── dataset2 (DAC 20) elections ──────────────────────────────────────────
@@ -3245,20 +3499,19 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(400, memberDac20.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService, never())
-        .createVoteForElection(eq(300), eq(memberDac20.getUserId()), eq(VoteType.CHAIRPERSON));
-    // chairDac10 gets only standard DAC votes for DAC 20's elections (not a chair of DAC 20)
-    verify(dacAutomationRuleService)
+        .createVoteForElection(300, memberDac20.getUserId(), VoteType.CHAIRPERSON);
+    // chairDac10 and memberDac10 are not members of DAC 20 → no votes in DAC 20's elections
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(300, chairDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(400, chairDac10.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService, never())
-        .createVoteForElection(eq(300), eq(chairDac10.getUserId()), eq(VoteType.CHAIRPERSON));
+        .createVoteForElection(300, chairDac10.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService, never())
-        .createVoteForElection(eq(300), eq(chairDac10.getUserId()), eq(VoteType.FINAL));
-    // memberDac10 gets only standard DAC votes for DAC 20's elections
-    verify(dacAutomationRuleService)
+        .createVoteForElection(300, chairDac10.getUserId(), VoteType.FINAL);
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(300, memberDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(400, memberDac10.getUserId(), VoteType.DAC);
   }
 
@@ -3424,14 +3677,13 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(100, sharedUser.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, sharedUser.getUserId(), VoteType.AGREEMENT);
-    // separateChairDac20 is not chair of DAC 10 → only DAC votes for dataset1
-    verify(dacAutomationRuleService)
+    // separateChairDac20 is not a member of DAC 10 → no votes for dataset1's elections
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(100, separateChairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
+    verify(dacAutomationRuleService, never())
         .createVoteForElection(200, separateChairDac20.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService, never())
-        .createVoteForElection(
-            eq(100), eq(separateChairDac20.getUserId()), eq(VoteType.CHAIRPERSON));
+        .createVoteForElection(100, separateChairDac20.getUserId(), VoteType.CHAIRPERSON);
 
     // ── dataset2 (DAC 20) ─────────────────────────────────────────────────────
     // sharedUser is member of DAC 20, not chair → only DAC votes
@@ -3440,9 +3692,9 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(400, sharedUser.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService, never())
-        .createVoteForElection(eq(300), eq(sharedUser.getUserId()), eq(VoteType.CHAIRPERSON));
+        .createVoteForElection(300, sharedUser.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService, never())
-        .createVoteForElection(eq(300), eq(sharedUser.getUserId()), eq(VoteType.FINAL));
+        .createVoteForElection(300, sharedUser.getUserId(), VoteType.FINAL);
     // separateChairDac20 is chair of DAC 20 → full chair votes
     verify(dacAutomationRuleService)
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.DAC);
@@ -3465,7 +3717,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
    * the automation path.
    */
   @Test
-  void testElectionVotes_AutoOpenOff_TwoDacs_NoElectionsOrVotesCreated() throws Exception {
+  void testElectionVotes_AutoOpenOff_TwoDacs_NoElectionsOrVotesCreated() {
     DarCollection collection = new DarCollection();
     collection.setDarCollectionId(1);
 
@@ -3509,7 +3761,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac10, dac20));
     // No auto-open rule for either DAC
     when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of());
-    when(userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId())).thenReturn(List.of());
     when(userDAO.findUsersForDatasetsByRole(anyList(), anyList()))
         .thenReturn(Set.of(chairDac10, chairDac20));
     when(userDAO.findUserById(any())).thenReturn(new User());
@@ -3648,6 +3899,560 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     election.setElectionId(1);
     election.setReferenceId(UUID.randomUUID().toString());
     return election;
+  }
+
+  /**
+   * Regression test: dacToDatasetsMap must be scoped per-user in the manual notification path.
+   *
+   * <p>With two chairs from different DACs, each user's NewDARRequestMessage must contain only the
+   * DAC/dataset entries for their own DAC — not a union of all prior users' entries.
+   */
+  @Test
+  void testNotifyUsersForDacs_ManualPath_EachUserReceivesOnlyTheirOwnDacDatasets()
+      throws Exception {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    DataAccessRequestData darData = new DataAccessRequestData();
+    dar.setData(darData);
+
+    DarCollection collection = new DarCollection();
+    collection.setDarCollectionId(1);
+    collection.setDarCode("DAR-TEST");
+
+    Dac dac10 = new Dac();
+    dac10.setDacId(10);
+    dac10.setName("DAC-10");
+
+    Dac dac20 = new Dac();
+    dac20.setDacId(20);
+    dac20.setName("DAC-20");
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+    dataset1.setAlias(1);
+    dataset1.setDatasetIdentifier();
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+    dataset2.setAlias(2);
+    dataset2.setDatasetIdentifier();
+
+    User chairDac10 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User chairDac20 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+
+    service.notifyUsersForDacs(
+        Set.of(chairDac10, chairDac20),
+        Set.of(dac10, dac20),
+        Set.of(dataset1, dataset2),
+        dar,
+        collection,
+        "Researcher Name",
+        false);
+
+    ArgumentCaptor<NewDARRequestMessage> captor =
+        ArgumentCaptor.forClass(NewDARRequestMessage.class);
+    verify(emailService, times(2)).sendMessage(captor.capture(), any());
+
+    List<NewDARRequestMessage> messages = captor.getAllValues();
+    NewDARRequestMessage msgForChair10 =
+        messages.stream()
+            .filter(m -> m.toUser.getUserId().equals(chairDac10.getUserId()))
+            .findFirst()
+            .orElseThrow();
+    NewDARRequestMessage msgForChair20 =
+        messages.stream()
+            .filter(m -> m.toUser.getUserId().equals(chairDac20.getUserId()))
+            .findFirst()
+            .orElseThrow();
+
+    @SuppressWarnings("unchecked")
+    Map<String, List<String>> chair10Map =
+        (Map<String, List<String>>) msgForChair10.createModel().get("dacDatasetGroups");
+    @SuppressWarnings("unchecked")
+    Map<String, List<String>> chair20Map =
+        (Map<String, List<String>>) msgForChair20.createModel().get("dacDatasetGroups");
+
+    String ds1Identifier = Dataset.parseAliasToIdentifier(1);
+    String ds2Identifier = Dataset.parseAliasToIdentifier(2);
+
+    // chairDac10 must see only DAC-10's dataset
+    assertTrue(chair10Map.containsKey("DAC-10"), "chair10 map should contain DAC-10");
+    assertFalse(chair10Map.containsKey("DAC-20"), "chair10 map must not contain DAC-20");
+    assertEquals(List.of(ds1Identifier), chair10Map.get("DAC-10"));
+
+    // chairDac20 must see only DAC-20's dataset
+    assertTrue(chair20Map.containsKey("DAC-20"), "chair20 map should contain DAC-20");
+    assertFalse(chair20Map.containsKey("DAC-10"), "chair20 map must not contain DAC-10");
+    assertEquals(List.of(ds2Identifier), chair20Map.get("DAC-20"));
+  }
+
+  /** Manual progress-report path — map isolation holds for NewProgressReportRequestMessage. */
+  @Test
+  void testNotifyUsersForDacs_ManualProgressReport_EachUserReceivesOnlyTheirOwnDacDatasets()
+      throws Exception {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.progressReport = true;
+    dar.setData(new DataAccessRequestData());
+
+    DarCollection collection = new DarCollection();
+    collection.setDarCode("DAR-PR");
+
+    Dac dac10 = new Dac();
+    dac10.setDacId(10);
+    dac10.setName("DAC-10");
+
+    Dac dac20 = new Dac();
+    dac20.setDacId(20);
+    dac20.setName("DAC-20");
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+    dataset1.setAlias(10);
+    dataset1.setDatasetIdentifier();
+
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+    dataset2.setAlias(20);
+    dataset2.setDatasetIdentifier();
+
+    User chairDac10 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User chairDac20 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+
+    service.notifyUsersForDacs(
+        Set.of(chairDac10, chairDac20),
+        Set.of(dac10, dac20),
+        Set.of(dataset1, dataset2),
+        dar,
+        collection,
+        "Researcher Name",
+        false);
+
+    ArgumentCaptor<NewProgressReportRequestMessage> captor =
+        ArgumentCaptor.forClass(NewProgressReportRequestMessage.class);
+    verify(emailService, times(2)).sendMessage(captor.capture(), any());
+
+    List<NewProgressReportRequestMessage> messages = captor.getAllValues();
+    NewProgressReportRequestMessage msgForChair10 =
+        messages.stream()
+            .filter(m -> m.toUser.getUserId().equals(chairDac10.getUserId()))
+            .findFirst()
+            .orElseThrow();
+    NewProgressReportRequestMessage msgForChair20 =
+        messages.stream()
+            .filter(m -> m.toUser.getUserId().equals(chairDac20.getUserId()))
+            .findFirst()
+            .orElseThrow();
+
+    @SuppressWarnings("unchecked")
+    Map<String, List<String>> chair10Map =
+        (Map<String, List<String>>) msgForChair10.createModel().get("dacDatasetGroups");
+    @SuppressWarnings("unchecked")
+    Map<String, List<String>> chair20Map =
+        (Map<String, List<String>>) msgForChair20.createModel().get("dacDatasetGroups");
+
+    assertTrue(chair10Map.containsKey("DAC-10"));
+    assertFalse(chair10Map.containsKey("DAC-20"), "chair10 must not see DAC-20's datasets");
+    assertTrue(chair20Map.containsKey("DAC-20"));
+    assertFalse(chair20Map.containsKey("DAC-10"), "chair20 must not see DAC-10's datasets");
+  }
+
+  /** Auto-open, non-progress-report: each user receives a NewCaseMessage, not a DAR request. */
+  @Test
+  void testNotifyUsersForDacs_AutoOpen_NonProgressReport_SendsNewCaseMessagePerUser()
+      throws Exception {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setData(new DataAccessRequestData());
+
+    DarCollection collection = new DarCollection();
+    collection.setDarCode("DAR-AUTO");
+
+    User chair1 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User member1 = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+
+    service.notifyUsersForDacs(
+        Set.of(chair1, member1), Set.of(), Set.of(), dar, collection, "Researcher Name", true);
+
+    verify(emailService, times(2)).sendMessage(any(NewCaseMessage.class), any());
+    verify(emailService, never()).sendMessage(any(NewDARRequestMessage.class), any());
+  }
+
+  /** Auto-open, progress-report: each user receives a NewProgressReportCaseMessage. */
+  @Test
+  void testNotifyUsersForDacs_AutoOpen_ProgressReport_SendsProgressReportCaseMessagePerUser()
+      throws Exception {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.progressReport = true;
+    dar.setData(new DataAccessRequestData());
+
+    DarCollection collection = new DarCollection();
+    collection.setDarCode("DAR-PR-AUTO");
+
+    User chair1 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User member1 = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+
+    service.notifyUsersForDacs(
+        Set.of(chair1, member1), Set.of(), Set.of(), dar, collection, "Researcher Name", true);
+
+    verify(emailService, times(2)).sendMessage(any(NewProgressReportCaseMessage.class), any());
+    verify(emailService, never()).sendMessage(any(NewDARRequestMessage.class), any());
+  }
+
+  /** Empty user set — no email interactions at all. */
+  @Test
+  void testNotifyUsersForDacs_EmptyUsers_NoEmailsSent() throws Exception {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setData(new DataAccessRequestData());
+
+    DarCollection collection = new DarCollection();
+    collection.setDarCode("DAR-EMPTY");
+
+    service.notifyUsersForDacs(
+        Set.of(), Set.of(), Set.of(), dar, collection, "Researcher Name", false);
+
+    verifyNoInteractions(emailService);
+  }
+
+  /**
+   * User whose DAC role does not match any DAC in the notification set receives an email with an
+   * empty dacDatasetGroups map — no data from other users leaks in.
+   */
+  @Test
+  void testNotifyUsersForDacs_ManualPath_UserWithNoMatchingDac_ReceivesEmptyMap() throws Exception {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setData(new DataAccessRequestData());
+
+    DarCollection collection = new DarCollection();
+    collection.setDarCode("DAR-NOMATCH");
+
+    Dac dac10 = new Dac();
+    dac10.setDacId(10);
+    dac10.setName("DAC-10");
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+    dataset1.setAlias(1);
+    dataset1.setDatasetIdentifier();
+
+    // User has CHAIRPERSON role for DAC 99, which is not in the notification DAC set
+    User chairDac99 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 99);
+
+    service.notifyUsersForDacs(
+        Set.of(chairDac99),
+        Set.of(dac10),
+        Set.of(dataset1),
+        dar,
+        collection,
+        "Researcher Name",
+        false);
+
+    ArgumentCaptor<NewDARRequestMessage> captor =
+        ArgumentCaptor.forClass(NewDARRequestMessage.class);
+    verify(emailService).sendMessage(captor.capture(), eq(chairDac99.getUserId()));
+
+    @SuppressWarnings("unchecked")
+    Map<String, List<String>> recipientMap =
+        (Map<String, List<String>>) captor.getValue().createModel().get("dacDatasetGroups");
+
+    assertTrue(recipientMap.isEmpty(), "user with no matching DAC should receive empty map");
+  }
+
+  // ─── filterUsersForDac ──────────────────────────────────────────────────────
+
+  @Test
+  void testFilterUsersForDac_ReturnsChairAndMemberForMatchingDac() {
+    User chair10 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User member10 = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+    User chair20 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+
+    Set<User> result = service.filterUsersForDac(Set.of(chair10, member10, chair20), 10);
+
+    assertEquals(2, result.size());
+    assertTrue(result.contains(chair10));
+    assertTrue(result.contains(member10));
+    assertFalse(result.contains(chair20));
+  }
+
+  @Test
+  void testFilterUsersForDac_EmptyInput_ReturnsEmpty() {
+    assertTrue(service.filterUsersForDac(Set.of(), 10).isEmpty());
+  }
+
+  // ─── addUsers ───────────────────────────────────────────────────────────────
+
+  @Test
+  void testAddUsers_AutoOpen_IncludesBothChairAndMember() {
+    Set<User> target = new HashSet<>();
+    User chair = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User member = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+
+    service.addUsers(target, 10, List.of(chair, member), true);
+
+    assertEquals(Set.of(chair, member), target);
+  }
+
+  @Test
+  void testAddUsers_AutoOpen_ExcludesUserFromDifferentDac() {
+    Set<User> target = new HashSet<>();
+    User chairOtherDac = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+
+    service.addUsers(target, 10, List.of(chairOtherDac), true);
+
+    assertTrue(target.isEmpty());
+  }
+
+  @Test
+  void testAddUsers_Manual_IncludesChair_ExcludesMember() {
+    Set<User> target = new HashSet<>();
+    User chair = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User member = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+
+    service.addUsers(target, 10, List.of(chair, member), false);
+
+    assertTrue(target.contains(chair));
+    assertFalse(target.contains(member));
+  }
+
+  @Test
+  void testAddUsers_Manual_ExcludesChairFromDifferentDac() {
+    Set<User> target = new HashSet<>();
+    User chairOtherDac = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+
+    service.addUsers(target, 10, List.of(chairOtherDac), false);
+
+    assertTrue(target.isEmpty());
+  }
+
+  // ─── classifyDacsAndUsers ───────────────────────────────────────────────────
+
+  @Test
+  void testClassifyDacsAndUsers_AutoOpen_PopulatesAllAutoOpenFields() {
+    Dac dac = new Dac();
+    dac.setDacId(10);
+
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(10);
+
+    User chair = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User member = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+
+    DACAutomationRule autoOpenRule = mock(DACAutomationRule.class);
+    when(autoOpenRule.ruleType()).thenReturn(DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS);
+    when(autoOpenRule.enabledByUserId()).thenReturn(chair.getUserId());
+    when(dacAutomationRuleService.findAllByDacId(10)).thenReturn(List.of(autoOpenRule));
+
+    DacUserClassification result =
+        service.classifyDacsAndUsers(List.of(dac), List.of(dataset), List.of(chair, member));
+
+    assertTrue(result.autoOpenDacs.contains(dac));
+    assertTrue(result.autoOpenDatasets.contains(dataset));
+    assertTrue(result.autoOpenUsers.contains(chair));
+    assertTrue(result.autoOpenUsers.contains(member));
+    assertEquals(chair.getUserId(), result.autoOpenUserIds.get(10));
+    assertTrue(result.manualOpenDacs.isEmpty());
+    assertTrue(result.manualOpenDatasets.isEmpty());
+    assertTrue(result.manualOpenUsers.isEmpty());
+  }
+
+  @Test
+  void testClassifyDacsAndUsers_ManualOpen_MemberExcluded() {
+    Dac dac = new Dac();
+    dac.setDacId(10);
+
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(10);
+
+    User chair = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User member = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+
+    when(dacAutomationRuleService.findAllByDacId(10)).thenReturn(List.of());
+
+    DacUserClassification result =
+        service.classifyDacsAndUsers(List.of(dac), List.of(dataset), List.of(chair, member));
+
+    assertTrue(result.manualOpenDacs.contains(dac));
+    assertTrue(result.manualOpenDatasets.contains(dataset));
+    assertTrue(result.manualOpenUsers.contains(chair));
+    assertFalse(result.manualOpenUsers.contains(member));
+    assertTrue(result.autoOpenDacs.isEmpty());
+    assertTrue(result.autoOpenDatasets.isEmpty());
+    assertTrue(result.autoOpenUsers.isEmpty());
+    assertTrue(result.autoOpenUserIds.isEmpty());
+  }
+
+  @Test
+  void testClassifyDacsAndUsers_MixedDacs_PartitionsCorrectly() {
+    Dac dac10 = new Dac();
+    dac10.setDacId(10);
+    Dac dac20 = new Dac();
+    dac20.setDacId(20);
+
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    dataset1.setDacId(10);
+    Dataset dataset2 = new Dataset();
+    dataset2.setDatasetId(2);
+    dataset2.setDacId(20);
+
+    User chair10 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User chair20 = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 20);
+
+    DACAutomationRule autoOpenRule = mock(DACAutomationRule.class);
+    when(autoOpenRule.ruleType()).thenReturn(DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS);
+    when(autoOpenRule.enabledByUserId()).thenReturn(chair10.getUserId());
+    when(dacAutomationRuleService.findAllByDacId(10)).thenReturn(List.of(autoOpenRule));
+    when(dacAutomationRuleService.findAllByDacId(20)).thenReturn(List.of());
+
+    DacUserClassification result =
+        service.classifyDacsAndUsers(
+            List.of(dac10, dac20), List.of(dataset1, dataset2), List.of(chair10, chair20));
+
+    assertTrue(result.autoOpenDacs.contains(dac10));
+    assertFalse(result.autoOpenDacs.contains(dac20));
+    assertTrue(result.autoOpenDatasets.contains(dataset1));
+    assertFalse(result.autoOpenDatasets.contains(dataset2));
+    assertTrue(result.autoOpenUsers.contains(chair10));
+    assertFalse(result.autoOpenUsers.contains(chair20));
+    assertEquals(chair10.getUserId(), result.autoOpenUserIds.get(10));
+    assertFalse(result.autoOpenUserIds.containsKey(20));
+
+    assertTrue(result.manualOpenDacs.contains(dac20));
+    assertFalse(result.manualOpenDacs.contains(dac10));
+    assertTrue(result.manualOpenDatasets.contains(dataset2));
+    assertFalse(result.manualOpenDatasets.contains(dataset1));
+    assertTrue(result.manualOpenUsers.contains(chair20));
+    assertFalse(result.manualOpenUsers.contains(chair10));
+  }
+
+  @Test
+  void testClassifyDacsAndUsers_DatasetWithNoMatchingDac_DacNotAddedToResult() {
+    // dataset references dacId=10, but no Dac object with id=10 is in dacsForDar
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(10);
+
+    User chair = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+
+    DACAutomationRule autoOpenRule = mock(DACAutomationRule.class);
+    when(autoOpenRule.ruleType()).thenReturn(DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS);
+    when(autoOpenRule.enabledByUserId()).thenReturn(chair.getUserId());
+    when(dacAutomationRuleService.findAllByDacId(10)).thenReturn(List.of(autoOpenRule));
+
+    DacUserClassification result =
+        service.classifyDacsAndUsers(List.of(), List.of(dataset), List.of(chair));
+
+    // DAC object is absent (null guard in classifyDacsAndUsers prevents adding null)
+    assertTrue(result.autoOpenDacs.isEmpty());
+    // Dataset, users, and userIds are still classified despite the missing DAC object
+    assertTrue(result.autoOpenDatasets.contains(dataset));
+    assertTrue(result.autoOpenUsers.contains(chair));
+    assertEquals(chair.getUserId(), result.autoOpenUserIds.get(10));
+  }
+
+  // ─── SO-approval gate in createElectionsAndVotesForAutoOpenDacs ─────────────
+
+  @Test
+  void testCreateElectionsAndVotesForAutoOpenDacs_SoApprovalPending_NoElectionsCreated() {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setRequiresSOApproval(true);
+    // approvingSigningOfficialUserId defaults to null — SO approval is still pending.
+    // The guard returns before consulting the classification, so its contents are irrelevant.
+    DacUserClassification classification = new DacUserClassification();
+
+    service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
+
+    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), any(), any());
+    verify(dacAutomationRuleService, never()).createVoteForElection(anyInt(), anyInt(), any());
+  }
+
+  // ─── DAO role-list assertion ─────────────────────────────────────────────────
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testCreateElectionsForNewDarCollection_FetchesOnlyChairAndMemberRoles() {
+    DarCollection collection = new DarCollection();
+    collection.setDarCollectionId(1);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setDatasetIds(List.of(1));
+    collection.addDar(dar);
+
+    when(darCollectionDAO.findDARCollectionByCollectionId(1)).thenReturn(collection);
+    when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of());
+    when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of());
+    ArgumentCaptor<List<Integer>> roleCaptor = ArgumentCaptor.forClass(List.class);
+    when(userDAO.findUsersForDatasetsByRole(anyList(), roleCaptor.capture())).thenReturn(Set.of());
+
+    service.createElectionsForNewDarCollection(1);
+
+    List<Integer> capturedRoleIds = roleCaptor.getValue();
+    assertTrue(capturedRoleIds.contains(UserRoles.CHAIRPERSON.getRoleId()));
+    assertTrue(capturedRoleIds.contains(UserRoles.MEMBER.getRoleId()));
+    assertFalse(
+        capturedRoleIds.contains(UserRoles.ADMIN.getRoleId()), "ADMIN role must not be fetched");
+  }
+
+  // ─── Member excluded from manual notification (integration) ─────────────────
+
+  @Test
+  void testSendNewDARCollectionMessage_ManualDac_MemberExcluded_OnlyChairNotified()
+      throws Exception {
+    DarCollection collection = new DarCollection();
+    collection.setDarCollectionId(1);
+
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setData(new DataAccessRequestData());
+
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(10);
+    dataset.setAlias(1);
+    dataset.setDatasetIdentifier();
+
+    dar.setDatasetIds(List.of(dataset.getDatasetId()));
+    collection.addDar(dar);
+
+    Dac dac = new Dac();
+    dac.setDacId(10);
+    dac.setName("DAC-10");
+
+    User chair = createUserWithRoleAndDacId(UserRoles.CHAIRPERSON, 10);
+    User member = createUserWithRoleAndDacId(UserRoles.MEMBER, 10);
+
+    when(darCollectionDAO.findDARCollectionByCollectionId(1)).thenReturn(collection);
+    when(userDAO.findUserById(any())).thenReturn(new User());
+    when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of(dataset));
+    when(dacDAO.findDacsForDatasetIds(anyList())).thenReturn(Set.of(dac));
+    when(dacAutomationRuleService.findAllByDacId(anyInt())).thenReturn(List.of());
+    // anyList() for roles is intentional here — role-list sourcing is verified separately in
+    // testCreateElectionsForNewDarCollection_FetchesOnlyChairAndMemberRoles.
+    // This test focuses on classification and notification: the DAO returns both chair and
+    // member; only the chair (classified into manualOpenUsers) should receive an email.
+    when(userDAO.findUsersForDatasetsByRole(anyList(), anyList()))
+        .thenReturn(Set.of(chair, member));
+
+    service.sendNewDARCollectionMessage(1);
+
+    ArgumentCaptor<NewDARRequestMessage> captor =
+        ArgumentCaptor.forClass(NewDARRequestMessage.class);
+    verify(emailService, times(1)).sendMessage(captor.capture(), any());
+    assertEquals(
+        chair.getUserId(),
+        captor.getValue().toUser.getUserId(),
+        "Only the chair should receive a manual-open notification, not the member");
   }
 
   private User createUserWithRole(UserRoles userRoles) {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3602](https://broadworkbench.atlassian.net/browse/DT-3602)

### Summary

Adjusts behavior of how votes are created so that:
Chairs are notified of new DARs when 'autoOpen' is turned off (admins removed)
Chairs and members are notified to vote on DARs when 'autoOpen' is on (admins removed)
Chairs and members (not Admins) can vote.

Issues addressed:

- Admins were being added to DARs for voting and notification
- Members were not included in DARs for voting or notifications about open elections
- Testing was limited

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
