### PR TITLE
[DT-3586] Adds new endpoint for enriched signing official information.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -530,6 +530,17 @@ public interface UserDAO extends Transactional<UserDAO> {
         """)
   List<User> getSOsByInstitution(@Bind("institutionId") Integer institutionId);
 
+  @RegisterBeanMapper(value = User.class)
+  @SqlQuery(
+      """
+          SELECT u.user_id, u.display_name, u.email, u.institution_id, u.user_data FROM users u
+          LEFT JOIN user_role ur ON ur.user_id = u.user_id
+          LEFT JOIN roles r ON r.role_id = ur.role_id
+          WHERE LOWER(r.name) = 'signingofficial'
+          AND u.institution_id = :institutionId
+        """)
+  List<User> getSOsWithDataByInstitution(@Bind("institutionId") Integer institutionId);
+
   @SqlUpdate("UPDATE users SET email_preference = :emailPreference WHERE user_id = :userId")
   void updateEmailPreference(
       @Bind("userId") Integer userId, @Bind("emailPreference") Boolean emailPreference);

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -530,12 +530,23 @@ public interface UserDAO extends Transactional<UserDAO> {
         """)
   List<User> getSOsByInstitution(@Bind("institutionId") Integer institutionId);
 
-  @RegisterBeanMapper(value = User.class)
+  @RegisterBeanMapper(value = User.class, prefix = "u")
+  @RegisterBeanMapper(value = Institution.class, prefix = "i")
+  @UseRowReducer(UserWithRolesReducer.class)
   @SqlQuery(
       """
-          SELECT u.user_id, u.display_name, u.email, u.institution_id, u.user_data FROM users u
+          SELECT
+              u.user_id as u_user_id,
+              u.display_name as u_display_name,
+              u.email as u_email,
+              u.institution_id as u_institution_id,
+              u.user_data as u_user_data,
+              i.institution_id as i_id,
+              i.institution_name as i_name
+          FROM users u
           LEFT JOIN user_role ur ON ur.user_id = u.user_id
           LEFT JOIN roles r ON r.role_id = ur.role_id
+          LEFT JOIN institution i ON i.institution_id = u.institution_id
           WHERE LOWER(r.name) = 'signingofficial'
           AND u.institution_id = :institutionId
         """)

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -414,16 +414,16 @@ public class UserResource extends Resource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/institution/{institutionId}/signing-officials")
-  @RolesAllowed({ADMIN, CHAIRPERSON, RESEARCHER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, RESEARCHER})
   public Response getSigningOfficialsByInstitution(
       @Auth AuthUser authUser, @PathParam("institutionId") Integer institutionId) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
       if (!user.hasUserRole(UserRoles.ADMIN)
           && !user.hasUserRole(UserRoles.CHAIRPERSON)
+          && !user.hasUserRole(UserRoles.MEMBER)
           && !Objects.equals(user.getInstitutionId(), institutionId)) {
-        throw new ForbiddenException(
-            "Researchers may only view signing officials from their own institution.");
+        throw new ForbiddenException("Researchers may only query their own institution.");
       }
       List<SigningOfficialUser> signingOfficials =
           userService.findSOsWithDataByInstitutionId(institutionId);

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -50,6 +50,7 @@ import org.broadinstitute.consent.http.service.AcknowledgementService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.NihService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.UserService.SigningOfficialUser;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.feature.InstitutionAndLibraryCardEnforcement;
 import org.broadinstitute.consent.http.service.sam.SamService;
@@ -405,6 +406,28 @@ public class UserResource extends Resource {
         return Response.ok().entity(signingOfficials).build();
       }
       return Response.ok().entity(Collections.emptyList()).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/institution/{institutionId}/signing-officials")
+  @RolesAllowed({ADMIN, CHAIRPERSON, RESEARCHER})
+  public Response getSigningOfficialsByInstitution(
+      @Auth AuthUser authUser, @PathParam("institutionId") Integer institutionId) {
+    try {
+      User user = userService.findUserByEmail(authUser.getEmail());
+      if (!user.hasUserRole(UserRoles.ADMIN)
+          && !user.hasUserRole(UserRoles.CHAIRPERSON)
+          && !Objects.equals(user.getInstitutionId(), institutionId)) {
+        throw new ForbiddenException(
+            "Researchers may only view signing officials from their own institution.");
+      }
+      List<SigningOfficialUser> signingOfficials =
+          userService.findSOsWithDataByInstitutionId(institutionId);
+      return Response.ok().entity(signingOfficials).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -467,6 +467,26 @@ public class UserService implements ConsentLogger {
     public void setUserData(Map<String, Object> userData) {
       this.userData = userData;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      SigningOfficialUser that = (SigningOfficialUser) o;
+      return Objects.equals(userData, that.userData);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), userData);
+    }
   }
 
   public static class SimplifiedUser {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -452,10 +452,12 @@ public class UserService implements ConsentLogger {
   public static class SigningOfficialUser extends SimplifiedUser {
 
     private Map<String, Object> userData;
+    private String institutionName;
 
     public SigningOfficialUser(User user) {
       super(user);
       this.userData = user.getUserData();
+      this.institutionName = user.getInstitution() != null ? user.getInstitution().getName() : null;
     }
 
     public SigningOfficialUser() {}
@@ -466,6 +468,14 @@ public class UserService implements ConsentLogger {
 
     public void setUserData(Map<String, Object> userData) {
       this.userData = userData;
+    }
+
+    public String getInstitutionName() {
+      return institutionName;
+    }
+
+    public void setInstitutionName(String institutionName) {
+      this.institutionName = institutionName;
     }
 
     @Override
@@ -480,12 +490,13 @@ public class UserService implements ConsentLogger {
         return false;
       }
       SigningOfficialUser that = (SigningOfficialUser) o;
-      return Objects.equals(userData, that.userData);
+      return Objects.equals(userData, that.userData)
+          && Objects.equals(institutionName, that.institutionName);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(super.hashCode(), userData);
+      return Objects.hash(super.hashCode(), userData, institutionName);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.NotFoundException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -261,6 +262,14 @@ public class UserService implements ConsentLogger {
     return users.stream().map(SimplifiedUser::new).toList();
   }
 
+  public List<SigningOfficialUser> findSOsWithDataByInstitutionId(Integer institutionId) {
+    if (Objects.isNull(institutionId)) {
+      return Collections.emptyList();
+    }
+    List<User> users = userDAO.getSOsWithDataByInstitution(institutionId);
+    return users.stream().map(SigningOfficialUser::new).toList();
+  }
+
   public List<User> findUsersByInstitutionId(Integer institutionId) {
     if (Objects.isNull(institutionId)) {
       throw new IllegalArgumentException();
@@ -438,6 +447,26 @@ public class UserService implements ConsentLogger {
   public void redactUser(User adminUser, String email) {
     User target = findUserByEmail(email);
     userRedactionAuditDAO.redactUser(target.getUserId(), adminUser.getUserId());
+  }
+
+  public static class SigningOfficialUser extends SimplifiedUser {
+
+    private Map<String, Object> userData;
+
+    public SigningOfficialUser(User user) {
+      super(user);
+      this.userData = user.getUserData();
+    }
+
+    public SigningOfficialUser() {}
+
+    public Map<String, Object> getUserData() {
+      return userData;
+    }
+
+    public void setUserData(Map<String, Object> userData) {
+      this.userData = userData;
+    }
   }
 
   public static class SimplifiedUser {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -770,6 +770,8 @@ paths:
     $ref: './paths/getApprovedDatasets.yaml'
   /api/user/institution/{institutionId}:
     $ref: './paths/userInstitutionByInstitutionId.yaml'
+  /api/user/institution/{institutionId}/signing-officials:
+    $ref: './paths/userInstitutionSigningOfficials.yaml'
   /api/user/signing-officials:
     get:
       summary: Find SOs for currently authenticated user's institution
@@ -1093,6 +1095,8 @@ components:
       $ref: './schemas/MatchResult.yaml'
     SimplifiedUser:
       $ref: './schemas/SimplifiedUser.yaml'
+    SigningOfficialUser:
+      $ref: './schemas/SigningOfficialUser.yaml'
     SamSelfDiagnostics:
       $ref: './schemas/SamSelfDiagnostics.yaml'
     SamUserInfo:

--- a/src/main/resources/assets/paths/userInstitutionSigningOfficials.yaml
+++ b/src/main/resources/assets/paths/userInstitutionSigningOfficials.yaml
@@ -6,8 +6,8 @@ get:
     Results always reflect the requested institution, never the caller's own institution.
 
     **Access rules:**
-    - **Admins** and **DAC Chairpersons** may supply any `institutionId` and will
-      receive the signing officials for that institution, regardless of their own
+    - **Admins**, **DAC Chairpersons**, and **DAC Members** may supply any `institutionId`
+      and will receive the signing officials for that institution, regardless of their own
       institution membership.
     - **Researchers** must supply the `institutionId` of the institution they belong
       to. Requesting any other institution's signing officials returns `403 Forbidden`.
@@ -18,8 +18,8 @@ get:
       in: path
       description: |
         The ID of the institution whose signing officials to retrieve.
-        Researchers must pass their own institution's ID; Admins and DAC Chairpersons
-        may pass any institution's ID.
+        Researchers must pass their own institution's ID; Admins, DAC Chairpersons,
+        and DAC Members may pass any institution's ID.
       required: true
       schema:
         type: integer
@@ -37,8 +37,8 @@ get:
               $ref: '../schemas/SigningOfficialUser.yaml'
     403:
       description: >
-        Forbidden — the authenticated Researcher requested an institution other
-        than their own.
+        Forbidden — the authenticated user is a Researcher who requested an institution
+        other than their own.
     404:
       description: Authenticated user not found
     500:

--- a/src/main/resources/assets/paths/userInstitutionSigningOfficials.yaml
+++ b/src/main/resources/assets/paths/userInstitutionSigningOfficials.yaml
@@ -1,0 +1,45 @@
+get:
+  summary: Find signing officials for an institution
+  operationId: apiUserInstitutionInstitutionIdSigningOfficialsGet
+  description: |
+    Returns the signing officials belonging to the institution identified by `institutionId`.
+    Results always reflect the requested institution, never the caller's own institution.
+
+    **Access rules:**
+    - **Admins** and **DAC Chairpersons** may supply any `institutionId` and will
+      receive the signing officials for that institution, regardless of their own
+      institution membership.
+    - **Researchers** must supply the `institutionId` of the institution they belong
+      to. Requesting any other institution's signing officials returns `403 Forbidden`.
+  tags:
+    - User
+  parameters:
+    - name: institutionId
+      in: path
+      description: |
+        The ID of the institution whose signing officials to retrieve.
+        Researchers must pass their own institution's ID; Admins and DAC Chairpersons
+        may pass any institution's ID.
+      required: true
+      schema:
+        type: integer
+  responses:
+    200:
+      description: >
+        An array of signing officials belonging to the requested institution.
+        Each entry includes the fields from SimplifiedUser (userId, displayName,
+        email, institutionId) plus the freeform userData stored in users.user_data.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/SigningOfficialUser.yaml'
+    403:
+      description: >
+        Forbidden — the authenticated Researcher requested an institution other
+        than their own.
+    404:
+      description: Authenticated user not found
+    500:
+      description: Internal server error

--- a/src/main/resources/assets/schemas/SigningOfficialUser.yaml
+++ b/src/main/resources/assets/schemas/SigningOfficialUser.yaml
@@ -5,6 +5,9 @@ allOf:
       institutionId:
         type: integer
         description: The institution this signing official belongs to
+      institutionName:
+        type: string
+        description: The display name of the institution this signing official belongs to
       userData:
         type: object
         description: Arbitrary JSON data stored in the users.user_data column

--- a/src/main/resources/assets/schemas/SigningOfficialUser.yaml
+++ b/src/main/resources/assets/schemas/SigningOfficialUser.yaml
@@ -1,0 +1,11 @@
+allOf:
+  - $ref: './SimplifiedUser.yaml'
+  - type: object
+    properties:
+      institutionId:
+        type: integer
+        description: The institution this signing official belongs to
+      userData:
+        type: object
+        description: Arbitrary JSON data stored in the users.user_data column
+        additionalProperties: true

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -566,6 +566,32 @@ class UserResourceTest extends AbstractTestHelper {
 
   @Test
   @SuppressWarnings("unchecked")
+  void testGetSigningOfficialsByInstitution_AsMember_DifferentInstitution() {
+    // DAC member belongs to institution 7 but queries institution 99 — must succeed.
+    Integer memberInstitutionId = 7;
+    Integer queriedInstitutionId = 99;
+    User member = createUserWithRole();
+    member.setInstitutionId(memberInstitutionId);
+    member.addRole(UserRoles.Member());
+    UserService.SigningOfficialUser so = new UserService.SigningOfficialUser();
+    so.setUserId(5);
+    so.setDisplayName("SO User");
+    so.setEmail("so@test.com");
+    so.setInstitutionId(queriedInstitutionId);
+    when(userService.findUserByEmail(any())).thenReturn(member);
+    when(userService.findSOsWithDataByInstitutionId(queriedInstitutionId)).thenReturn(List.of(so));
+
+    Response response =
+        userResource.getSigningOfficialsByInstitution(authUser, queriedInstitutionId);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    List<UserService.SigningOfficialUser> body =
+        (List<UserService.SigningOfficialUser>) response.getEntity();
+    assertEquals(1, body.size());
+    assertEquals(queriedInstitutionId, body.getFirst().getInstitutionId());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
   void testGetSigningOfficialsByInstitution_AsResearcher_OwnInstitution() {
     Integer institutionId = 5;
     User researcher = createUserWithRole();

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -510,6 +510,123 @@ class UserResourceTest extends AbstractTestHelper {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void testGetSigningOfficialsByInstitution_AsAdmin_DifferentInstitution() {
+    // Admin belongs to institution 1 but queries institution 99 — must succeed.
+    Integer adminInstitutionId = 1;
+    Integer queriedInstitutionId = 99;
+    User admin = createUserWithInstitution(); // institutionId = 1
+    admin.addRole(UserRoles.Admin());
+    UserService.SigningOfficialUser so = new UserService.SigningOfficialUser();
+    so.setUserId(2);
+    so.setDisplayName("SO User");
+    so.setEmail("so@test.com");
+    so.setInstitutionId(queriedInstitutionId);
+    so.setUserData(Map.of("department", "biology"));
+    when(userService.findUserByEmail(any())).thenReturn(admin);
+    when(userService.findSOsWithDataByInstitutionId(queriedInstitutionId)).thenReturn(List.of(so));
+
+    Response response =
+        userResource.getSigningOfficialsByInstitution(authUser, queriedInstitutionId);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    List<UserService.SigningOfficialUser> body =
+        (List<UserService.SigningOfficialUser>) response.getEntity();
+    assertEquals(1, body.size());
+    assertEquals(so.getDisplayName(), body.getFirst().getDisplayName());
+    // Confirm the result belongs to the queried institution, not the admin's own.
+    assertEquals(queriedInstitutionId, body.getFirst().getInstitutionId());
+    assertEquals(so.getUserData(), body.getFirst().getUserData());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testGetSigningOfficialsByInstitution_AsChairperson_DifferentInstitution() {
+    // Chairperson belongs to institution 3 but queries institution 99 — must succeed.
+    Integer chairInstitutionId = 3;
+    Integer queriedInstitutionId = 99;
+    User chair = createUserWithRole();
+    chair.setInstitutionId(chairInstitutionId);
+    chair.addRole(UserRoles.Chairperson());
+    UserService.SigningOfficialUser so = new UserService.SigningOfficialUser();
+    so.setUserId(3);
+    so.setDisplayName("SO User");
+    so.setEmail("so@test.com");
+    so.setInstitutionId(queriedInstitutionId);
+    when(userService.findUserByEmail(any())).thenReturn(chair);
+    when(userService.findSOsWithDataByInstitutionId(queriedInstitutionId)).thenReturn(List.of(so));
+
+    Response response =
+        userResource.getSigningOfficialsByInstitution(authUser, queriedInstitutionId);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    List<UserService.SigningOfficialUser> body =
+        (List<UserService.SigningOfficialUser>) response.getEntity();
+    assertEquals(1, body.size());
+    // Confirm the result belongs to the queried institution, not the chair's own.
+    assertEquals(queriedInstitutionId, body.getFirst().getInstitutionId());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testGetSigningOfficialsByInstitution_AsResearcher_OwnInstitution() {
+    Integer institutionId = 5;
+    User researcher = createUserWithRole();
+    researcher.setInstitutionId(institutionId);
+    UserService.SigningOfficialUser so = new UserService.SigningOfficialUser();
+    so.setUserId(4);
+    so.setDisplayName("SO User");
+    so.setEmail("so@test.com");
+    so.setInstitutionId(institutionId);
+    when(userService.findUserByEmail(any())).thenReturn(researcher);
+    when(userService.findSOsWithDataByInstitutionId(institutionId)).thenReturn(List.of(so));
+
+    Response response = userResource.getSigningOfficialsByInstitution(authUser, institutionId);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    List<UserService.SigningOfficialUser> body =
+        (List<UserService.SigningOfficialUser>) response.getEntity();
+    assertEquals(1, body.size());
+  }
+
+  @Test
+  void testGetSigningOfficialsByInstitution_AsResearcher_DifferentInstitution() {
+    User researcher = createUserWithRole();
+    researcher.setInstitutionId(1);
+    when(userService.findUserByEmail(any())).thenReturn(researcher);
+
+    Response response = userResource.getSigningOfficialsByInstitution(authUser, 99);
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+  }
+
+  @Test
+  void testGetSigningOfficialsByInstitution_AsResearcher_NullInstitution() {
+    // Researcher with no institution set — Objects.equals(null, anyId) is false → 403
+    User researcher = createUserWithRole(); // institutionId is null
+    when(userService.findUserByEmail(any())).thenReturn(researcher);
+
+    Response response = userResource.getSigningOfficialsByInstitution(authUser, 5);
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+  }
+
+  @Test
+  void testGetSigningOfficialsByInstitution_ServiceThrows() {
+    User admin = createUserWithRole();
+    admin.addRole(UserRoles.Admin());
+    when(userService.findUserByEmail(any())).thenReturn(admin);
+    when(userService.findSOsWithDataByInstitutionId(any()))
+        .thenThrow(new RuntimeException("DB error"));
+
+    Response response = userResource.getSigningOfficialsByInstitution(authUser, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  @Test
+  void testGetSigningOfficialsByInstitution_UserNotFound() {
+    when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
+
+    Response response = userResource.getSigningOfficialsByInstitution(authUser, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
   void testGetUsersByInstitutionNoInstitution() {
     Integer institutionId = 1;
     doThrow(new NotFoundException()).when(userService).findUsersByInstitutionId(institutionId);

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -513,7 +513,6 @@ class UserResourceTest extends AbstractTestHelper {
   @SuppressWarnings("unchecked")
   void testGetSigningOfficialsByInstitution_AsAdmin_DifferentInstitution() {
     // Admin belongs to institution 1 but queries institution 99 — must succeed.
-    Integer adminInstitutionId = 1;
     Integer queriedInstitutionId = 99;
     User admin = createUserWithInstitution(); // institutionId = 1
     admin.addRole(UserRoles.Admin());

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -980,4 +980,79 @@ class UserServiceTest extends AbstractTestHelper {
 
     assertThrows(NotFoundException.class, () -> service.redactUser(admin, unknownEmail));
   }
+
+  @Test
+  void testSigningOfficialUserEquals_sameInstance() {
+    User u = generateUser();
+    u.setUserData(Map.of("key", "value"));
+    UserService.SigningOfficialUser sou = new UserService.SigningOfficialUser(u);
+    assertEquals(sou, sou);
+  }
+
+  @Test
+  void testSigningOfficialUserEquals_equalUsersAndData() {
+    User u = generateUser();
+    u.setUserData(Map.of("key", "value"));
+    UserService.SigningOfficialUser sou1 = new UserService.SigningOfficialUser(u);
+    UserService.SigningOfficialUser sou2 = new UserService.SigningOfficialUser(u);
+    assertEquals(sou1, sou2);
+  }
+
+  @Test
+  void testSigningOfficialUserEquals_differentUserId() {
+    User u1 = generateUser();
+    u1.setUserData(Map.of("key", "value"));
+    User u2 = generateUser();
+    u2.setUserData(Map.of("key", "value"));
+    // Ensure distinct userIds
+    u2.setUserId(u1.getUserId() + 1000);
+    UserService.SigningOfficialUser sou1 = new UserService.SigningOfficialUser(u1);
+    UserService.SigningOfficialUser sou2 = new UserService.SigningOfficialUser(u2);
+    assertNotEquals(sou1, sou2);
+  }
+
+  @Test
+  void testSigningOfficialUserEquals_differentUserData() {
+    User u1 = generateUser();
+    u1.setUserData(Map.of("key", "value1"));
+    User u2 = generateUser();
+    u2.setUserId(u1.getUserId());
+    u2.setUserData(Map.of("key", "value2"));
+    UserService.SigningOfficialUser sou1 = new UserService.SigningOfficialUser(u1);
+    UserService.SigningOfficialUser sou2 = new UserService.SigningOfficialUser(u2);
+    assertNotEquals(sou1, sou2);
+  }
+
+  @Test
+  void testSigningOfficialUserEquals_null() {
+    User u = generateUser();
+    UserService.SigningOfficialUser sou = new UserService.SigningOfficialUser(u);
+    assertNotEquals(null, sou);
+  }
+
+  @Test
+  void testSigningOfficialUserEquals_differentType() {
+    User u = generateUser();
+    UserService.SigningOfficialUser sou = new UserService.SigningOfficialUser(u);
+    assertNotEquals(sou, u);
+  }
+
+  @Test
+  void testSigningOfficialUserHashCode_equalObjectsHaveEqualHash() {
+    User u = generateUser();
+    u.setUserData(Map.of("key", "value"));
+    UserService.SigningOfficialUser sou1 = new UserService.SigningOfficialUser(u);
+    UserService.SigningOfficialUser sou2 = new UserService.SigningOfficialUser(u);
+    assertEquals(sou1.hashCode(), sou2.hashCode());
+  }
+
+  @Test
+  void testSigningOfficialUserHashCode_differentUserIdProducesDifferentHash() {
+    User u1 = generateUser();
+    User u2 = generateUser();
+    u2.setUserId(u1.getUserId() + 1000);
+    UserService.SigningOfficialUser sou1 = new UserService.SigningOfficialUser(u1);
+    UserService.SigningOfficialUser sou2 = new UserService.SigningOfficialUser(u2);
+    assertNotEquals(sou1.hashCode(), sou2.hashCode());
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -460,6 +460,34 @@ class UserServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testFindSOsWithDataByInstitutionId() {
+    User u = generateUser();
+    u.setUserData(Map.of("key", "value"));
+    Integer institutionId = u.getInstitutionId();
+    when(userDAO.getSOsWithDataByInstitution(any())).thenReturn(List.of(u));
+    List<UserService.SigningOfficialUser> users =
+        service.findSOsWithDataByInstitutionId(institutionId);
+    assertEquals(1, users.size());
+    assertEquals(u.getDisplayName(), users.getFirst().getDisplayName());
+    assertEquals(u.getEmail(), users.getFirst().getEmail());
+    assertEquals(u.getInstitutionId(), users.getFirst().getInstitutionId());
+    assertEquals(u.getUserData(), users.getFirst().getUserData());
+  }
+
+  @Test
+  void testFindSOsWithDataByInstitutionId_NullId() {
+    List<UserService.SigningOfficialUser> users = service.findSOsWithDataByInstitutionId(null);
+    assertEquals(0, users.size());
+  }
+
+  @Test
+  void testFindSOsWithDataByInstitutionId_EmptyResult() {
+    when(userDAO.getSOsWithDataByInstitution(any())).thenReturn(Collections.emptyList());
+    List<UserService.SigningOfficialUser> users = service.findSOsWithDataByInstitutionId(1);
+    assertEquals(0, users.size());
+  }
+
+  @Test
   void testFindUsersByInstitutionIdNullId() {
     assertThrows(IllegalArgumentException.class, () -> service.findUsersByInstitutionId(null));
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -463,8 +463,11 @@ class UserServiceTest extends AbstractTestHelper {
   void testFindSOsWithDataByInstitutionId() {
     User u = generateUser();
     u.setUserData(Map.of("key", "value"));
+    Institution institution = new Institution();
+    institution.setName("Broad Institute");
+    u.setInstitution(institution);
     Integer institutionId = u.getInstitutionId();
-    when(userDAO.getSOsWithDataByInstitution(any())).thenReturn(List.of(u));
+    when(userDAO.getSOsWithDataByInstitution(institutionId)).thenReturn(List.of(u));
     List<UserService.SigningOfficialUser> users =
         service.findSOsWithDataByInstitutionId(institutionId);
     assertEquals(1, users.size());
@@ -472,6 +475,19 @@ class UserServiceTest extends AbstractTestHelper {
     assertEquals(u.getEmail(), users.getFirst().getEmail());
     assertEquals(u.getInstitutionId(), users.getFirst().getInstitutionId());
     assertEquals(u.getUserData(), users.getFirst().getUserData());
+    assertEquals("Broad Institute", users.getFirst().getInstitutionName());
+  }
+
+  @Test
+  void testFindSOsWithDataByInstitutionId_NullInstitution() {
+    User u = generateUser();
+    // user.getInstitution() is null — DAO found no matching institution row
+    Integer institutionId = u.getInstitutionId();
+    when(userDAO.getSOsWithDataByInstitution(institutionId)).thenReturn(List.of(u));
+    List<UserService.SigningOfficialUser> users =
+        service.findSOsWithDataByInstitutionId(institutionId);
+    assertEquals(1, users.size());
+    assertNull(users.getFirst().getInstitutionName());
   }
 
   @Test
@@ -1024,6 +1040,22 @@ class UserServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testSigningOfficialUserEquals_differentInstitutionName() {
+    User u1 = generateUser();
+    Institution inst1 = new Institution();
+    inst1.setName("Broad Institute");
+    u1.setInstitution(inst1);
+    User u2 = generateUser();
+    u2.setUserId(u1.getUserId());
+    Institution inst2 = new Institution();
+    inst2.setName("MIT");
+    u2.setInstitution(inst2);
+    UserService.SigningOfficialUser sou1 = new UserService.SigningOfficialUser(u1);
+    UserService.SigningOfficialUser sou2 = new UserService.SigningOfficialUser(u2);
+    assertNotEquals(sou1, sou2);
+  }
+
+  @Test
   void testSigningOfficialUserEquals_null() {
     User u = generateUser();
     UserService.SigningOfficialUser sou = new UserService.SigningOfficialUser(u);
@@ -1054,5 +1086,13 @@ class UserServiceTest extends AbstractTestHelper {
     UserService.SigningOfficialUser sou1 = new UserService.SigningOfficialUser(u1);
     UserService.SigningOfficialUser sou2 = new UserService.SigningOfficialUser(u2);
     assertNotEquals(sou1.hashCode(), sou2.hashCode());
+  }
+
+  @Test
+  void testSigningOfficialUserGetterSetterInstitutionName() {
+    UserService.SigningOfficialUser sou = new UserService.SigningOfficialUser();
+    assertNull(sou.getInstitutionName());
+    sou.setInstitutionName("Broad Institute");
+    assertEquals("Broad Institute", sou.getInstitutionName());
   }
 }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3586](https://broadworkbench.atlassian.net/browse/DT-3586)

### Summary

Adds new endpoint to provide the 'user_data' information back to the user along with the basic signing official information without creating new avenues for this information to leak.

<img width="1455" height="1035" alt="image" src="https://github.com/user-attachments/assets/0971e9fd-7cce-4bde-a555-c333d98f1001" />


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
