### PR TITLE
DT-3606: BFF session infrastructure: user_sessions, user_session_audit, and tests

### DIFF
--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -250,4 +250,6 @@
   <include file="changesets/changelog-consent-2026-04-28-dar-dataset-daa-snapshot.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-06-02-study-pi-email.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-06-11-drop-datarequest-researchpurpose.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-06-16-bff-01-user-sessions.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-06-16-bff-02-user-session-audit.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-06-16-bff-01-user-sessions.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-06-16-bff-01-user-sessions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+  <changeSet id="changelog-consent-2026-06-16-bff-user-sessions" author="grushton">
+    <!--
+      BFF Epic 1 (DT-3606): session store table for the Fastify server-side session layer.
+      The pgStore (server/src/session/pgStore.ts) reads/writes against sid, sess, and expire.
+      idp records which identity provider authenticated the session ('google' | 'azure') and
+      is kept in sync with the sess JSON blob by the sync_session_idp trigger defined in
+      the companion audit changeset. Rows are purged by an hourly pg_cron job; the expire
+      index supports both that DELETE and the get() query filter (expire > NOW()).
+    -->
+    <sql splitStatements="false">
+      CREATE TABLE user_sessions (
+        sid    VARCHAR     NOT NULL COLLATE "default",
+        sess   JSON        NOT NULL,
+        expire TIMESTAMP   NOT NULL,
+        idp    VARCHAR(16),
+        CONSTRAINT session_pkey PRIMARY KEY (sid)
+      )
+    </sql>
+    <createIndex indexName="idx_session_expire" tableName="user_sessions">
+      <column name="expire"/>
+    </createIndex>
+    <rollback>
+      <dropIndex indexName="idx_session_expire" tableName="user_sessions"/>
+      <dropTable tableName="user_sessions"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-06-16-bff-02-user-session-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-06-16-bff-02-user-session-audit.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+  <changeSet id="changelog-consent-2026-06-16-bff-user-session-audit" author="grushton">
+    <!--
+      BFF Epic 1 (DT-3606): audit trail for BFF user sessions.
+
+      Stores metadata only — never tokens, never the raw session id. sid_hash is
+      SHA-256(sid) so a specific session can be correlated during an incident or
+      dbGaP audit without exposing a usable credential.
+
+      Four triggers on user_sessions keep this table current automatically so no
+      application code path can skip the audit:
+        sync_session_idp     — BEFORE INSERT OR UPDATE: mirrors idp column from sess JSON
+        audit_session_start  — AFTER INSERT:            creates the audit row
+        audit_session_update — AFTER UPDATE:            backfills user_email / idp once
+                               authentication completes (userId is not yet set when the
+                               session row is first inserted during PKCE initiation)
+        audit_session_end    — AFTER DELETE:            stamps ended_at; defaults
+                               end_reason to 'expired' (the Phase 2 logout handler sets
+                               'logout' before calling session.destroy())
+
+      Retention is enforced by a weekly pg_cron job (see runbook); 24 months is the
+      starting point — confirm the period with the team before production rollout.
+    -->
+    <sql splitStatements="false">
+      CREATE TABLE user_session_audit (
+        id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        sid_hash   VARCHAR(64)  NOT NULL,
+        user_email VARCHAR(255),
+        idp        VARCHAR(16),
+        created_at TIMESTAMP    NOT NULL DEFAULT NOW(),
+        ended_at   TIMESTAMP,
+        end_reason VARCHAR(16)
+      )
+    </sql>
+
+    <createIndex indexName="idx_session_audit_email" tableName="user_session_audit">
+      <column name="user_email"/>
+    </createIndex>
+    <createIndex indexName="idx_session_audit_sid" tableName="user_session_audit">
+      <column name="sid_hash"/>
+    </createIndex>
+
+    <!-- ################################################################## -->
+    <!-- Trigger 1: keep user_sessions.idp in sync with the sess JSON blob  -->
+    <!-- ################################################################## -->
+    <sql splitStatements="false">
+      CREATE OR REPLACE FUNCTION sync_session_idp() RETURNS trigger AS $$
+      BEGIN
+        NEW.idp := NEW.sess->>'idp';
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    </sql>
+    <sql splitStatements="false">
+      CREATE TRIGGER user_sessions_sync_idp
+        BEFORE INSERT OR UPDATE ON user_sessions
+        FOR EACH ROW EXECUTE FUNCTION sync_session_idp()
+    </sql>
+
+    <!-- ################################################################## -->
+    <!-- Trigger 2: open an audit row when a session is created             -->
+    <!-- ################################################################## -->
+    <sql splitStatements="false">
+      CREATE OR REPLACE FUNCTION audit_session_start() RETURNS trigger AS $$
+      BEGIN
+        INSERT INTO user_session_audit (sid_hash, user_email, idp)
+        VALUES (
+          encode(sha256(NEW.sid::bytea), 'hex'),
+          NEW.sess->>'userId',
+          NEW.sess->>'idp'
+        );
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    </sql>
+    <sql splitStatements="false">
+      CREATE TRIGGER user_sessions_audit_start
+        AFTER INSERT ON user_sessions
+        FOR EACH ROW EXECUTE FUNCTION audit_session_start()
+    </sql>
+
+    <!-- ################################################################## -->
+    <!-- Trigger 3: backfill user_email / idp once the OAuth callback       -->
+    <!--            completes and the session JSON is populated             -->
+    <!-- ################################################################## -->
+    <sql splitStatements="false">
+      CREATE OR REPLACE FUNCTION audit_session_update() RETURNS trigger AS $$
+      BEGIN
+        UPDATE user_session_audit
+           SET user_email = COALESCE(user_email, NEW.sess->>'userId'),
+               idp        = COALESCE(idp, NEW.sess->>'idp')
+         WHERE sid_hash = encode(sha256(NEW.sid::bytea), 'hex');
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    </sql>
+    <sql splitStatements="false">
+      CREATE TRIGGER user_sessions_audit_update
+        AFTER UPDATE ON user_sessions
+        FOR EACH ROW EXECUTE FUNCTION audit_session_update()
+    </sql>
+
+    <!-- ################################################################## -->
+    <!-- Trigger 4: close the audit row when a session is destroyed         -->
+    <!--            end_reason defaults to 'expired'; the logout handler    -->
+    <!--            stamps 'logout' before calling session.destroy()        -->
+    <!-- ################################################################## -->
+    <sql splitStatements="false">
+      CREATE OR REPLACE FUNCTION audit_session_end() RETURNS trigger AS $$
+      BEGIN
+        UPDATE user_session_audit
+           SET ended_at   = NOW(),
+               end_reason = COALESCE(end_reason, 'expired')
+         WHERE sid_hash = encode(sha256(OLD.sid::bytea), 'hex')
+           AND ended_at IS NULL;
+        RETURN OLD;
+      END;
+      $$ LANGUAGE plpgsql
+    </sql>
+    <sql splitStatements="false">
+      CREATE TRIGGER user_sessions_audit_end
+        AFTER DELETE ON user_sessions
+        FOR EACH ROW EXECUTE FUNCTION audit_session_end()
+    </sql>
+
+    <rollback>
+      <!--
+        Drop triggers before functions (triggers depend on them),
+        then drop the audit table.
+      -->
+      <sql>DROP TRIGGER IF EXISTS user_sessions_sync_idp     ON user_sessions</sql>
+      <sql>DROP TRIGGER IF EXISTS user_sessions_audit_start  ON user_sessions</sql>
+      <sql>DROP TRIGGER IF EXISTS user_sessions_audit_update ON user_sessions</sql>
+      <sql>DROP TRIGGER IF EXISTS user_sessions_audit_end    ON user_sessions</sql>
+      <sql>DROP FUNCTION IF EXISTS sync_session_idp()</sql>
+      <sql>DROP FUNCTION IF EXISTS audit_session_start()</sql>
+      <sql>DROP FUNCTION IF EXISTS audit_session_update()</sql>
+      <sql>DROP FUNCTION IF EXISTS audit_session_end()</sql>
+      <dropIndex indexName="idx_session_audit_email" tableName="user_session_audit"/>
+      <dropIndex indexName="idx_session_audit_sid"   tableName="user_session_audit"/>
+      <dropTable tableName="user_session_audit"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-06-16-bff-02-user-session-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-06-16-bff-02-user-session-audit.xml
@@ -93,7 +93,9 @@
         UPDATE user_session_audit
            SET user_email = COALESCE(user_email, NEW.sess->>'userId'),
                idp        = COALESCE(idp, NEW.sess->>'idp')
-         WHERE sid_hash = encode(sha256(NEW.sid::bytea), 'hex');
+         WHERE sid_hash = encode(sha256(NEW.sid::bytea), 'hex')
+           AND ended_at IS NULL
+           AND (user_email IS NULL OR idp IS NULL);
         RETURN NEW;
       END;
       $$ LANGUAGE plpgsql

--- a/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /* WARNING: This test class makes use of underlying Java Cryptographic functions.  If these cryptographic operations were to reach production code and customer requirements dictate, this code would need to be running in a FIPS compliant JVM.
-*/
+ */
 class UserSessionTest extends DAOTestHelper {
 
   // ---------------------------------------------------------------------------

--- a/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
+/* WARNING: This test class makes use of underlying Java Cryptographic functions.  If these cryptographic operations were to reach production code and customer requirements dictate, this code would need to be running in a FIPS compliant JVM.
+*/
 class UserSessionTest extends DAOTestHelper {
 
   // ---------------------------------------------------------------------------

--- a/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
@@ -1,0 +1,225 @@
+package org.broadinstitute.consent.http.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UserSessionTest extends DAOTestHelper {
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Mirrors encode(sha256(sid::bytea), 'hex') used inside the trigger functions. */
+  private static String sha256Hex(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(hash.length * 2);
+      for (byte b : hash) {
+        hex.append(String.format("%02x", b));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void insertSession(String sid, String sessJson) {
+    jdbi.useHandle(
+        h ->
+            h.execute(
+                "INSERT INTO user_sessions (sid, sess, expire) VALUES (?, ?::json, NOW() + INTERVAL '8 hours')",
+                sid,
+                sessJson));
+  }
+
+  private void updateSessionSess(String sid, String sessJson) {
+    jdbi.useHandle(
+        h -> h.execute("UPDATE user_sessions SET sess = ?::json WHERE sid = ?", sessJson, sid));
+  }
+
+  private void deleteSession(String sid) {
+    jdbi.useHandle(h -> h.execute("DELETE FROM user_sessions WHERE sid = ?", sid));
+  }
+
+  private Map<String, Object> querySession(String sid) {
+    return jdbi.withHandle(
+        h ->
+            Objects.requireNonNull(
+                h.createQuery("SELECT * FROM user_sessions WHERE sid = :sid")
+                    .bind("sid", sid)
+                    .mapToMap()
+                    .findOne()
+                    .orElse(null)));
+  }
+
+  private Map<String, Object> queryAuditBySid(String sid) {
+    return jdbi.withHandle(
+        h ->
+            Objects.requireNonNull(
+                h.createQuery("SELECT * FROM user_session_audit WHERE sid_hash = :hash")
+                    .bind("hash", sha256Hex(sid))
+                    .mapToMap()
+                    .findOne()
+                    .orElse(null)));
+  }
+
+  /** Simulates the Phase 2 logout handler stamping end_reason before session.destroy(). */
+  private void stampAuditEndReason(String sid) {
+    jdbi.useHandle(
+        h ->
+            h.execute(
+                "UPDATE user_session_audit SET end_reason = ? WHERE sid_hash = ? AND ended_at IS NULL",
+                "logout",
+                sha256Hex(sid)));
+  }
+
+  // ---------------------------------------------------------------------------
+  // sync_session_idp — BEFORE INSERT OR UPDATE
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void syncIdp_populatesIdpColumnOnInsert() {
+    String sid = UUID.randomUUID().toString();
+    insertSession(sid, "{\"idp\":\"google\"}");
+
+    Map<String, Object> row = querySession(sid);
+    assertNotNull(row);
+    assertEquals("google", row.get("idp"));
+  }
+
+  @Test
+  void syncIdp_updatesIdpColumnWhenSessJsonChanges() {
+    String sid = UUID.randomUUID().toString();
+    insertSession(sid, "{\"idp\":\"google\"}");
+
+    updateSessionSess(sid, "{\"idp\":\"azure\"}");
+
+    assertEquals("azure", querySession(sid).get("idp"));
+  }
+
+  @Test
+  void syncIdp_nullWhenIdpAbsentFromSessJson() {
+    String sid = UUID.randomUUID().toString();
+    insertSession(sid, "{}");
+
+    assertNull(querySession(sid).get("idp"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // audit_session_start — AFTER INSERT
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void auditStart_createsAuditRowOnInsert() {
+    String sid = UUID.randomUUID().toString();
+    insertSession(sid, "{\"idp\":\"google\",\"userId\":\"researcher@example.com\"}");
+
+    Map<String, Object> audit = queryAuditBySid(sid);
+    assertNotNull(audit);
+    assertEquals(sha256Hex(sid), audit.get("sid_hash"));
+    assertEquals("researcher@example.com", audit.get("user_email"));
+    assertEquals("google", audit.get("idp"));
+    assertNotNull(audit.get("created_at"));
+    assertNull(audit.get("ended_at"));
+    assertNull(audit.get("end_reason"));
+  }
+
+  @Test
+  void auditStart_nullEmailWhenUserIdAbsentFromSessJson() {
+    // Simulates PKCE initiation: the session row is created before the OAuth
+    // callback populates userId, so the audit row opens with a null user_email.
+    String sid = UUID.randomUUID().toString();
+    insertSession(sid, "{\"idp\":\"azure\"}");
+
+    Map<String, Object> audit = queryAuditBySid(sid);
+    assertNotNull(audit);
+    assertNull(audit.get("user_email"));
+    assertEquals("azure", audit.get("idp"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // audit_session_update — AFTER UPDATE
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void auditUpdate_backfillsEmailAndIdpAfterOAuthCallback() {
+    // Phase 1: PKCE initiation — session inserted without userId or idp.
+    String sid = UUID.randomUUID().toString();
+    insertSession(sid, "{}");
+
+    Map<String, Object> auditBefore = queryAuditBySid(sid);
+    assertNull(auditBefore.get("user_email"));
+    assertNull(auditBefore.get("idp"));
+
+    // Phase 2: OAuth callback — sess updated with userId and idp.
+    updateSessionSess(sid, "{\"userId\":\"researcher@example.com\",\"idp\":\"google\"}");
+
+    Map<String, Object> auditAfter = queryAuditBySid(sid);
+    assertEquals("researcher@example.com", auditAfter.get("user_email"));
+    assertEquals("google", auditAfter.get("idp"));
+  }
+
+  @Test
+  void auditUpdate_doesNotOverwriteEmailOrIdpAlreadySet() {
+    // COALESCE means once user_email and idp are recorded they cannot be
+    // changed by a subsequent session update (e.g. a rolling-expiry touch).
+    String sid = UUID.randomUUID().toString();
+    insertSession(sid, "{\"userId\":\"first@example.com\",\"idp\":\"google\"}");
+
+    updateSessionSess(sid, "{\"userId\":\"second@example.com\",\"idp\":\"azure\"}");
+
+    Map<String, Object> audit = queryAuditBySid(sid);
+    assertEquals("first@example.com", audit.get("user_email"));
+    assertEquals("google", audit.get("idp"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // audit_session_end — AFTER DELETE
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void auditEnd_stampsEndedAtWithExpiredReasonOnDelete() {
+    String sid = UUID.randomUUID().toString();
+    insertSession(
+        sid,
+        """
+        {"idp":"google","userId":"researcher@example.com"}
+        """);
+
+    deleteSession(sid);
+
+    Map<String, Object> audit = queryAuditBySid(sid);
+    assertNotNull(audit.get("ended_at"));
+    assertEquals("expired", audit.get("end_reason"));
+  }
+
+  @Test
+  void auditEnd_preservesLogoutReasonSetByLogoutHandlerBeforeDelete() {
+    // The Phase 2 logout handler stamps end_reason = 'logout' on the audit row
+    // before calling session.destroy().  The AFTER DELETE trigger's COALESCE
+    // must not overwrite it with 'expired'.
+    String sid = UUID.randomUUID().toString();
+    insertSession(
+        sid,
+        """
+        {"idp":"google","userId":"researcher@example.com"}
+        """);
+    stampAuditEndReason(sid);
+
+    deleteSession(sid);
+
+    Map<String, Object> audit = queryAuditBySid(sid);
+    assertNotNull(audit.get("ended_at"));
+    assertEquals("logout", audit.get("end_reason"));
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -51,26 +51,22 @@ class UserSessionTest extends DAOTestHelper {
     jdbi.useHandle(h -> h.execute("DELETE FROM user_sessions WHERE sid = ?", sid));
   }
 
-  private Map<String, Object> querySession(String sid) {
+  private Optional<Map<String, Object>> querySession(String sid) {
     return jdbi.withHandle(
         h ->
-            Objects.requireNonNull(
-                h.createQuery("SELECT * FROM user_sessions WHERE sid = :sid")
-                    .bind("sid", sid)
-                    .mapToMap()
-                    .findOne()
-                    .orElse(null)));
+            h.createQuery("SELECT * FROM user_sessions WHERE sid = :sid")
+                .bind("sid", sid)
+                .mapToMap()
+                .findOne());
   }
 
-  private Map<String, Object> queryAuditBySid(String sid) {
+  private Optional<Map<String, Object>> queryAuditBySid(String sid) {
     return jdbi.withHandle(
         h ->
-            Objects.requireNonNull(
-                h.createQuery("SELECT * FROM user_session_audit WHERE sid_hash = :hash")
-                    .bind("hash", sha256Hex(sid))
-                    .mapToMap()
-                    .findOne()
-                    .orElse(null)));
+            h.createQuery("SELECT * FROM user_session_audit WHERE sid_hash = :hash")
+                .bind("hash", sha256Hex(sid))
+                .mapToMap()
+                .findOne());
   }
 
   /** Simulates the Phase 2 logout handler stamping end_reason before session.destroy(). */
@@ -92,8 +88,7 @@ class UserSessionTest extends DAOTestHelper {
     String sid = UUID.randomUUID().toString();
     insertSession(sid, "{\"idp\":\"google\"}");
 
-    Map<String, Object> row = querySession(sid);
-    assertNotNull(row);
+    Map<String, Object> row = querySession(sid).orElseThrow();
     assertEquals("google", row.get("idp"));
   }
 
@@ -104,7 +99,7 @@ class UserSessionTest extends DAOTestHelper {
 
     updateSessionSess(sid, "{\"idp\":\"azure\"}");
 
-    assertEquals("azure", querySession(sid).get("idp"));
+    assertEquals("azure", querySession(sid).orElseThrow().get("idp"));
   }
 
   @Test
@@ -112,7 +107,7 @@ class UserSessionTest extends DAOTestHelper {
     String sid = UUID.randomUUID().toString();
     insertSession(sid, "{}");
 
-    assertNull(querySession(sid).get("idp"));
+    assertNull(querySession(sid).orElseThrow().get("idp"));
   }
 
   // ---------------------------------------------------------------------------
@@ -124,8 +119,7 @@ class UserSessionTest extends DAOTestHelper {
     String sid = UUID.randomUUID().toString();
     insertSession(sid, "{\"idp\":\"google\",\"userId\":\"researcher@example.com\"}");
 
-    Map<String, Object> audit = queryAuditBySid(sid);
-    assertNotNull(audit);
+    Map<String, Object> audit = queryAuditBySid(sid).orElseThrow();
     assertEquals(sha256Hex(sid), audit.get("sid_hash"));
     assertEquals("researcher@example.com", audit.get("user_email"));
     assertEquals("google", audit.get("idp"));
@@ -141,8 +135,7 @@ class UserSessionTest extends DAOTestHelper {
     String sid = UUID.randomUUID().toString();
     insertSession(sid, "{\"idp\":\"azure\"}");
 
-    Map<String, Object> audit = queryAuditBySid(sid);
-    assertNotNull(audit);
+    Map<String, Object> audit = queryAuditBySid(sid).orElseThrow();
     assertNull(audit.get("user_email"));
     assertEquals("azure", audit.get("idp"));
   }
@@ -157,14 +150,14 @@ class UserSessionTest extends DAOTestHelper {
     String sid = UUID.randomUUID().toString();
     insertSession(sid, "{}");
 
-    Map<String, Object> auditBefore = queryAuditBySid(sid);
+    Map<String, Object> auditBefore = queryAuditBySid(sid).orElseThrow();
     assertNull(auditBefore.get("user_email"));
     assertNull(auditBefore.get("idp"));
 
     // Phase 2: OAuth callback — sess updated with userId and idp.
     updateSessionSess(sid, "{\"userId\":\"researcher@example.com\",\"idp\":\"google\"}");
 
-    Map<String, Object> auditAfter = queryAuditBySid(sid);
+    Map<String, Object> auditAfter = queryAuditBySid(sid).orElseThrow();
     assertEquals("researcher@example.com", auditAfter.get("user_email"));
     assertEquals("google", auditAfter.get("idp"));
   }
@@ -178,7 +171,7 @@ class UserSessionTest extends DAOTestHelper {
 
     updateSessionSess(sid, "{\"userId\":\"second@example.com\",\"idp\":\"azure\"}");
 
-    Map<String, Object> audit = queryAuditBySid(sid);
+    Map<String, Object> audit = queryAuditBySid(sid).orElseThrow();
     assertEquals("first@example.com", audit.get("user_email"));
     assertEquals("google", audit.get("idp"));
   }
@@ -193,12 +186,12 @@ class UserSessionTest extends DAOTestHelper {
     insertSession(
         sid,
         """
-        {"idp":"google","userId":"researcher@example.com"}
-        """);
+            {"idp":"google","userId":"researcher@example.com"}
+            """);
 
     deleteSession(sid);
 
-    Map<String, Object> audit = queryAuditBySid(sid);
+    Map<String, Object> audit = queryAuditBySid(sid).orElseThrow();
     assertNotNull(audit.get("ended_at"));
     assertEquals("expired", audit.get("end_reason"));
   }
@@ -212,13 +205,13 @@ class UserSessionTest extends DAOTestHelper {
     insertSession(
         sid,
         """
-        {"idp":"google","userId":"researcher@example.com"}
-        """);
+            {"idp":"google","userId":"researcher@example.com"}
+            """);
     stampAuditEndReason(sid);
 
     deleteSession(sid);
 
-    Map<String, Object> audit = queryAuditBySid(sid);
+    Map<String, Object> audit = queryAuditBySid(sid).orElseThrow();
     assertNotNull(audit.get("ended_at"));
     assertEquals("logout", audit.get("end_reason"));
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserSessionTest.java
@@ -15,71 +15,6 @@ import org.junit.jupiter.api.Test;
 class UserSessionTest extends DAOTestHelper {
 
   // ---------------------------------------------------------------------------
-  // Helpers
-  // ---------------------------------------------------------------------------
-
-  /** Mirrors encode(sha256(sid::bytea), 'hex') used inside the trigger functions. */
-  private static String sha256Hex(String value) {
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
-      StringBuilder hex = new StringBuilder(hash.length * 2);
-      for (byte b : hash) {
-        hex.append(String.format("%02x", b));
-      }
-      return hex.toString();
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private void insertSession(String sid, String sessJson) {
-    jdbi.useHandle(
-        h ->
-            h.execute(
-                "INSERT INTO user_sessions (sid, sess, expire) VALUES (?, ?::json, NOW() + INTERVAL '8 hours')",
-                sid,
-                sessJson));
-  }
-
-  private void updateSessionSess(String sid, String sessJson) {
-    jdbi.useHandle(
-        h -> h.execute("UPDATE user_sessions SET sess = ?::json WHERE sid = ?", sessJson, sid));
-  }
-
-  private void deleteSession(String sid) {
-    jdbi.useHandle(h -> h.execute("DELETE FROM user_sessions WHERE sid = ?", sid));
-  }
-
-  private Optional<Map<String, Object>> querySession(String sid) {
-    return jdbi.withHandle(
-        h ->
-            h.createQuery("SELECT * FROM user_sessions WHERE sid = :sid")
-                .bind("sid", sid)
-                .mapToMap()
-                .findOne());
-  }
-
-  private Optional<Map<String, Object>> queryAuditBySid(String sid) {
-    return jdbi.withHandle(
-        h ->
-            h.createQuery("SELECT * FROM user_session_audit WHERE sid_hash = :hash")
-                .bind("hash", sha256Hex(sid))
-                .mapToMap()
-                .findOne());
-  }
-
-  /** Simulates the Phase 2 logout handler stamping end_reason before session.destroy(). */
-  private void stampAuditEndReason(String sid) {
-    jdbi.useHandle(
-        h ->
-            h.execute(
-                "UPDATE user_session_audit SET end_reason = ? WHERE sid_hash = ? AND ended_at IS NULL",
-                "logout",
-                sha256Hex(sid)));
-  }
-
-  // ---------------------------------------------------------------------------
   // sync_session_idp — BEFORE INSERT OR UPDATE
   // ---------------------------------------------------------------------------
 
@@ -214,5 +149,70 @@ class UserSessionTest extends DAOTestHelper {
     Map<String, Object> audit = queryAuditBySid(sid).orElseThrow();
     assertNotNull(audit.get("ended_at"));
     assertEquals("logout", audit.get("end_reason"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Mirrors encode(sha256(sid::bytea), 'hex') used inside the trigger functions. */
+  private static String sha256Hex(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(hash.length * 2);
+      for (byte b : hash) {
+        hex.append(String.format("%02x", b));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void insertSession(String sid, String sessJson) {
+    jdbi.useHandle(
+        h ->
+            h.execute(
+                "INSERT INTO user_sessions (sid, sess, expire) VALUES (?, ?::json, NOW() + INTERVAL '8 hours')",
+                sid,
+                sessJson));
+  }
+
+  private void updateSessionSess(String sid, String sessJson) {
+    jdbi.useHandle(
+        h -> h.execute("UPDATE user_sessions SET sess = ?::json WHERE sid = ?", sessJson, sid));
+  }
+
+  private void deleteSession(String sid) {
+    jdbi.useHandle(h -> h.execute("DELETE FROM user_sessions WHERE sid = ?", sid));
+  }
+
+  private Optional<Map<String, Object>> querySession(String sid) {
+    return jdbi.withHandle(
+        h ->
+            h.createQuery("SELECT * FROM user_sessions WHERE sid = :sid")
+                .bind("sid", sid)
+                .mapToMap()
+                .findOne());
+  }
+
+  private Optional<Map<String, Object>> queryAuditBySid(String sid) {
+    return jdbi.withHandle(
+        h ->
+            h.createQuery("SELECT * FROM user_session_audit WHERE sid_hash = :hash")
+                .bind("hash", sha256Hex(sid))
+                .mapToMap()
+                .findOne());
+  }
+
+  /** Simulates the Phase 2 logout handler stamping end_reason before session.destroy(). */
+  private void stampAuditEndReason(String sid) {
+    jdbi.useHandle(
+        h ->
+            h.execute(
+                "UPDATE user_session_audit SET end_reason = ? WHERE sid_hash = ? AND ended_at IS NULL",
+                "logout",
+                sha256Hex(sid)));
   }
 }


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3606

## Summary

Adds the two PostgreSQL tables required for the BFF server-side session layer (Epic 1, DT-3606). No Java application code reads or writes these tables — they are owned entirely by the Fastify BFF server's `pgStore`. The migrations land in the consent repo because that is where all schema changes for the consent database live.

- **`user_sessions`** — the session store table. `@fastify/session` + the custom `pgStore` (duos-ui) read/write `sid`, `sess` (JSON blob), and `expire`. An `idp` column (`'google'` | `'azure'`) is kept in sync with the session JSON by a database trigger so it can be queried directly for observability without parsing JSON.
- **`user_session_audit`** — metadata-only audit trail. Stores a SHA-256 hash of the session id (never the raw sid), user email, IDP, session start/end timestamps, and end reason (`logout` | `expired`). Four triggers on `user_sessions` populate it automatically so no application code path can bypass the audit record.

Both changesets include `<rollback>` blocks. The `user_sessions` expire index supports both the hourly `pg_cron` cleanup DELETE and the `pgStore` `get()` filter (`expire > NOW()`).

## Trigger functions

| Trigger | Fires | Effect |
|---|---|---|
| `sync_session_idp` | BEFORE INSERT OR UPDATE on `user_sessions` | Copies `sess->>'idp'` into the native `idp` column |
| `audit_session_start` | AFTER INSERT on `user_sessions` | Creates the audit row with SHA-256 sid hash |
| `audit_session_update` | AFTER UPDATE on `user_sessions` | Backfills `user_email` / `idp` via COALESCE once the OAuth callback populates the session |
| `audit_session_end` | AFTER DELETE on `user_sessions` | Stamps `ended_at`; defaults `end_reason` to `'expired'` — the Phase 2 logout handler sets `'logout'` on the audit row before calling `session.destroy()` |

## Tests

`UserSessionTest` exercises all four triggers against a real Testcontainers PostgreSQL 16 instance via the existing `DAOTestHelper` harness (no new infrastructure). Nine test cases cover the distinct behavioral paths including the COALESCE idempotency invariant and the logout-before-delete contract.


🤖 Generated with [Claude Code](https://claude.com/claude-code)