### PR TITLE
[DT-3614] Fix DAR chair summary status and Open actions

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -69,13 +69,12 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         ON dar_all.collection_id = c.collection_id
         AND dar_all.submission_date IS NOT NULL
         AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
-      -- Most recent Open and Closed Data Access Elections for DAC User datasets
-      -- Archived, Canceled, and Final elections are not used for status or action calculations
+      -- Most recent terminal or active Data Access Elections for DAC User datasets
       LEFT JOIN (
         SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
         FROM election
         WHERE LOWER(election.election_type) = 'dataaccess'
-        AND (LOWER(election.status) = 'open' OR LOWER(election.status) = 'closed')
+        AND LOWER(election.status) IN ('open', 'closed', 'canceled')
       ) AS e
         ON e.reference_id = latest_dar.reference_id
         AND e.dataset_id = d.dataset_id
@@ -87,6 +86,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       INNER JOIN dar_dataset dd
         ON latest_dar.reference_id = dd.reference_id
       WHERE dd.dataset_id = d.dataset_id
+        AND (e.latest = e.election_id OR e.election_id IS NULL)
       GROUP BY
         c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
         latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
@@ -326,7 +326,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       LEFT JOIN (
         SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
         FROM election
-        WHERE LOWER(election.election_type) = 'dataaccess' AND election.dataset_id IN (<datasetIds>)
+        WHERE LOWER(election.election_type) = 'dataaccess'
+        AND LOWER(election.status) IN ('open', 'closed', 'canceled')
+        AND election.dataset_id IN (<datasetIds>)
       ) AS e
         ON e.reference_id = latest_dar.reference_id
       LEFT JOIN vote v

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -285,10 +285,6 @@ public class DarCollectionService implements ConsentLogger {
         s -> {
           Map<String, Integer> statusCount = new HashMap<>();
           Map<Integer, Election> elections = s.getElections();
-          if ((!s.requiresSOApproval() || s.getSOApprover() != null)
-              && elections.size() < s.getDatasetCount()) {
-            s.addAction(DarCollectionActions.OPEN);
-          }
           elections
               .values()
               .forEach(election -> updateStatusCount(statusCount, election.getStatus()));
@@ -319,13 +315,23 @@ public class DarCollectionService implements ConsentLogger {
       return;
     }
 
-    // If there are no elections, only show open
-    if ((!summary.requiresSOApproval() || summary.getSOApprover() != null)
-        && summary.getElections().isEmpty()) {
+    boolean canOpen = !summary.requiresSOApproval() || summary.getSOApprover() != null;
+    boolean hasOpenElection = Objects.nonNull(openCount);
+    boolean hasReopenableElection =
+        summary.getElections().values().stream()
+            .map(election -> ElectionStatus.getStatusFromString(election.getStatus()))
+            .anyMatch(
+                status -> status == ElectionStatus.CLOSED || status == ElectionStatus.CANCELED);
+
+    // Only show open/re-open when there are no active elections to vote on.
+    if (canOpen
+        && !hasOpenElection
+        && (summary.getElections().isEmpty()
+            || summary.getElections().size() < summary.getDatasetCount()
+            || hasReopenableElection)) {
       summary.addAction(DarCollectionActions.OPEN);
     }
 
-    // If there are closed or canceled elections, show open
     // If there are any open elections, show vote
     summary
         .getElections()
@@ -333,15 +339,8 @@ public class DarCollectionService implements ConsentLogger {
         .forEach(
             election -> {
               ElectionStatus status = ElectionStatus.getStatusFromString(election.getStatus());
-              switch (Objects.requireNonNull(status)) {
-                case CLOSED, CANCELED:
-                  summary.addAction(DarCollectionActions.OPEN);
-                  break;
-                case OPEN:
-                  summary.addAction(DarCollectionActions.VOTE);
-                  break;
-                default:
-                  break;
+              if (Objects.requireNonNull(status) == ElectionStatus.OPEN) {
+                summary.addAction(DarCollectionActions.VOTE);
               }
             });
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -110,23 +110,30 @@ public class DarCollectionService implements ConsentLogger {
     statusCount.merge(Objects.requireNonNullElse(status, "Undefined"), 1, Integer::sum);
   }
 
+  private boolean hasElectionForEachDataset(DarCollectionSummary summary) {
+    Set<Integer> datasetIdsWithElections =
+        summary.getElections().values().stream()
+            .map(Election::getDatasetId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    if (!datasetIdsWithElections.isEmpty()) {
+      return datasetIdsWithElections.containsAll(summary.getDatasetIds());
+    }
+    return summary.getElections().size() >= summary.getDatasetCount();
+  }
+
   private void determineCollectionStatus(
-      DarCollectionSummary summary,
-      Map<String, Integer> statusCount,
-      Integer datasetCount,
-      Integer electionCount) {
-    // If there are no elections, status is unreviewed
-    // if there are some elections open, status is in process
-    // if all elections are closed or canceled and electionCount == datasetCount, status is complete
-    if (electionCount.equals(0)) {
+      DarCollectionSummary summary, Map<String, Integer> statusCount) {
+    // If there are no elections, status is unreviewed.
+    // If there are any open elections, status is in process.
+    // If all datasets have elections and none are open, status is complete.
+    if (summary.getElections().isEmpty()) {
       summary.setStatus(DarCollectionStatus.SUBMITTED.getValue());
-    } else if (electionCount.equals(datasetCount)) {
-      Integer openCount = statusCount.get(ElectionStatus.OPEN.getValue());
-      if (Objects.isNull(openCount)) {
-        summary.setStatus(DarCollectionStatus.COMPLETE.getValue());
-      } else {
-        summary.setStatus(DarCollectionStatus.IN_PROCESS.getValue());
-      }
+    } else if (Objects.nonNull(statusCount.get(ElectionStatus.OPEN.getValue()))) {
+      summary.setStatus(DarCollectionStatus.IN_PROCESS.getValue());
+    } else if (hasElectionForEachDataset(summary)) {
+      summary.setStatus(DarCollectionStatus.COMPLETE.getValue());
     } else {
       summary.setStatus(DarCollectionStatus.IN_PROCESS.getValue());
     }
@@ -152,7 +159,7 @@ public class DarCollectionService implements ConsentLogger {
                         s.addAction(DarCollectionActions.CANCEL);
                       }
                     });
-            determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
+            determineCollectionStatus(s, statusCount);
           }
           if (s.getCloseoutSupplement() != null) {
             s.getActions().clear();
@@ -221,7 +228,7 @@ public class DarCollectionService implements ConsentLogger {
               s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
             }
           } else {
-            determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
+            determineCollectionStatus(s, statusCount);
           }
         });
   }
@@ -264,10 +271,10 @@ public class DarCollectionService implements ConsentLogger {
               // some datasets do not have elections (in process)
               // all voted on (complete)
               // no elections
-              if (electionCount < s.getDatasetCount()) {
-                s.setStatus(DarCollectionStatus.IN_PROCESS.getValue());
-              } else {
+              if (hasElectionForEachDataset(s)) {
                 s.setStatus(DarCollectionStatus.COMPLETE.getValue());
+              } else {
+                s.setStatus(DarCollectionStatus.IN_PROCESS.getValue());
               }
             }
           }
@@ -290,7 +297,7 @@ public class DarCollectionService implements ConsentLogger {
               .forEach(election -> updateStatusCount(statusCount, election.getStatus()));
           Integer closedCount = statusCount.get(ElectionStatus.CLOSED.getValue());
           Integer openCount = statusCount.get(ElectionStatus.OPEN.getValue());
-          determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
+          determineCollectionStatus(s, statusCount);
           updateSummaryActionsForChair(s, closedCount, openCount);
         });
   }
@@ -357,7 +364,7 @@ public class DarCollectionService implements ConsentLogger {
           s.getElections()
               .values()
               .forEach(election -> updateStatusCount(statusCount, election.getStatus()));
-          determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
+          determineCollectionStatus(s, statusCount);
           updateSummaryActionsForSO(user, s);
         });
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1745,10 +1745,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     DarCollectionSummary testTwo = summaries.get(1);
     Set<String> expectedTwoActions =
-        Set.of(
-            DarCollectionActions.VOTE.getValue(),
-            DarCollectionActions.CANCEL.getValue(),
-            DarCollectionActions.OPEN.getValue());
+        Set.of(DarCollectionActions.VOTE.getValue(), DarCollectionActions.CANCEL.getValue());
     assertTrue(testTwo.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
     assertEquals(testTwo.getActions(), expectedTwoActions);
 
@@ -1763,8 +1760,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertEquals(testFour.getActions(), expectedFourActions);
 
     DarCollectionSummary testFive = summaries.get(4);
-    Set<String> expectedFiveActions =
-        Set.of(DarCollectionActions.OPEN.getValue(), DarCollectionActions.VOTE.getValue());
+    Set<String> expectedFiveActions = Set.of(DarCollectionActions.VOTE.getValue());
     assertTrue(testFive.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
     assertEquals(testFive.getActions(), expectedFiveActions);
 
@@ -2004,13 +2000,48 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaryResult);
 
     Set<String> expectedActions =
-        Set.of(
-            DarCollectionActions.VOTE.getValue(),
-            DarCollectionActions.CANCEL.getValue(),
-            DarCollectionActions.OPEN.getValue());
+        Set.of(DarCollectionActions.VOTE.getValue(), DarCollectionActions.CANCEL.getValue());
     assertTrue(
         summaryResult.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
     assertEquals(expectedActions, summaryResult.getActions());
+  }
+
+  @Test
+  void testGetSummaryForRoleByCollectionId_ChairDoesNotOpenWhenRpElectionIsOpen() {
+    Dac dac = new Dac();
+    dac.setDacId(1);
+    User user = new User();
+    user.setUserId(1);
+    user.setChairpersonRoleWithDAC(dac.getDacId());
+
+    DarCollectionSummary summary = new DarCollectionSummary();
+    Integer collectionId = randomInt(1, 100);
+    summary.setDarCollectionId(collectionId);
+    summary.addDatasetId(1);
+
+    Election dataAccessElection = new Election();
+    dataAccessElection.setElectionId(1);
+    dataAccessElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    dataAccessElection.setStatus(ElectionStatus.CLOSED.getValue());
+    summary.addElection(dataAccessElection);
+
+    Election rpElection = new Election();
+    rpElection.setElectionId(2);
+    rpElection.setElectionType(ElectionType.RP.getValue());
+    rpElection.setStatus(ElectionStatus.OPEN.getValue());
+    summary.addElection(rpElection);
+
+    when(darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(
+            user.getUserId(), List.of(), collectionId))
+        .thenReturn(summary);
+    when(datasetDAO.findDatasetIdsByDacIds(any())).thenReturn(List.of());
+
+    DarCollectionSummary summaryResult =
+        service.getSummaryForRoleByCollectionId(user, UserRoles.CHAIRPERSON, collectionId);
+
+    assertNotNull(summaryResult);
+    assertEquals(DarCollectionStatus.IN_PROCESS.getValue(), summaryResult.getStatus());
+    assertEquals(Set.of(DarCollectionActions.VOTE.getValue()), summaryResult.getActions());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -2045,6 +2045,47 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testGetSummaryForRoleByCollectionId_ChairCompletesWhenDatasetElectionsAreClosed() {
+    Dac dac = new Dac();
+    dac.setDacId(1);
+    User user = new User();
+    user.setUserId(1);
+    user.setChairpersonRoleWithDAC(dac.getDacId());
+
+    DarCollectionSummary summary = new DarCollectionSummary();
+    Integer collectionId = randomInt(1, 100);
+    Integer datasetId = 2161;
+    summary.setDarCollectionId(collectionId);
+    summary.addDatasetId(datasetId);
+
+    Election dataAccessElection = new Election();
+    dataAccessElection.setElectionId(1);
+    dataAccessElection.setDatasetId(datasetId);
+    dataAccessElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    dataAccessElection.setStatus(ElectionStatus.CLOSED.getValue());
+    summary.addElection(dataAccessElection);
+
+    Election rpElection = new Election();
+    rpElection.setElectionId(2);
+    rpElection.setDatasetId(datasetId);
+    rpElection.setElectionType(ElectionType.RP.getValue());
+    rpElection.setStatus(ElectionStatus.CLOSED.getValue());
+    summary.addElection(rpElection);
+
+    when(darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(
+            user.getUserId(), List.of(), collectionId))
+        .thenReturn(summary);
+    when(datasetDAO.findDatasetIdsByDacIds(any())).thenReturn(List.of());
+
+    DarCollectionSummary summaryResult =
+        service.getSummaryForRoleByCollectionId(user, UserRoles.CHAIRPERSON, collectionId);
+
+    assertNotNull(summaryResult);
+    assertEquals(DarCollectionStatus.COMPLETE.getValue(), summaryResult.getStatus());
+    assertEquals(Set.of(DarCollectionActions.OPEN.getValue()), summaryResult.getActions());
+  }
+
+  @Test
   void testGetSummaryForRoleByCollectionId_DACMember() {
     Dac dac = new Dac();
     dac.setDacId(1);


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3614

### Summary

Fixes chair DAR collection summaries so Open / Re-Open is not shown while active elections exist, and terminal election states are handled consistently.
Changes include:

- Only show `Open` when there are no open elections.
- Treat closed/canceled elections as terminal for summary status.
- Calculate `Complete` by dataset election coverage instead of raw election count.
- Include canceled latest `DataAccess` elections in chair summary queries.
- Ignore older elections by filtering to the latest election per dataset.
- Preserve archived DAR filtering from summary results.

Adds regression coverage for closed `DataAccess` / open `RP` and all-terminal election cases.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
