### PR TITLE
[DT-3615] Fix Elasticsearch conflicts during study deletion

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -21,13 +21,11 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -187,19 +185,7 @@ public class StudyResource extends Resource {
       if (!deletable) {
         throw new BadRequestException("Study has datasets that are in use and cannot be deleted.");
       }
-      Set<Integer> studyDatasetIds = study.getDatasetIds();
       datasetService.deleteStudy(study, user);
-      // Remove from ES index
-      studyDatasetIds.forEach(
-          id -> {
-            try (Response indexResponse = elasticSearchService.deleteIndex(id, user.getUserId())) {
-              if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
-                logWarn("Non-OK response when deleting index for dataset with id: " + id);
-              }
-            } catch (IOException e) {
-              logException(e);
-            }
-          });
       return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -166,6 +166,7 @@ public class ElasticSearchService implements ConsentLogger {
   public Response deleteIndex(Integer datasetId, Integer userId) throws IOException {
     Request deleteRequest =
         new Request(HttpMethod.POST, "/" + esConfig.getDatasetIndexName() + "/_delete_by_query");
+    deleteRequest.addParameter("conflicts", "proceed");
     deleteRequest.setEntity(
         new NStringEntity(DELETE_QUERY.formatted(datasetId), ContentType.APPLICATION_JSON));
     updateDatasetIndexDate(datasetId, userId, null);

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -2,17 +2,14 @@ package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.core.Response;
-import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -44,7 +41,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -380,12 +376,11 @@ class StudyResourceTest extends AbstractTestHelper {
     admin.setUserId(study.getCreateUserId());
     when(datasetService.getStudyWithDatasetsById(admin, study.getStudyId())).thenReturn(study);
     when(userService.findUserByEmail(any())).thenReturn(admin);
-    Response esResponse = Mockito.mock(Response.class);
-    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(esResponse);
 
     try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, times(1)).deleteIndex(any(), any());
+      verify(datasetService).deleteStudy(study, admin);
+      verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
   }
 
@@ -395,7 +390,7 @@ class StudyResourceTest extends AbstractTestHelper {
 
     try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any(), any());
+      verify(datasetService, never()).deleteStudy(any(), any());
     }
   }
 
@@ -411,7 +406,7 @@ class StudyResourceTest extends AbstractTestHelper {
 
     try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any(), any());
+      verify(datasetService, never()).deleteStudy(any(), any());
     }
   }
 
@@ -427,7 +422,7 @@ class StudyResourceTest extends AbstractTestHelper {
 
     try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any(), any());
+      verify(datasetService, never()).deleteStudy(any(), any());
     }
   }
 
@@ -443,7 +438,7 @@ class StudyResourceTest extends AbstractTestHelper {
 
     try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any(), any());
+      verify(datasetService).deleteStudy(study, admin);
     }
   }
 
@@ -460,12 +455,12 @@ class StudyResourceTest extends AbstractTestHelper {
 
     try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any(), any());
+      verify(datasetService).deleteStudy(study, admin);
     }
   }
 
   @Test
-  void testDeleteStudyByIdElasticSearchFailure() throws Exception {
+  void testDeleteStudyByIdDeleteFailure() throws Exception {
     Study study = createMockStudy();
     study.getDatasets().forEach(d -> d.setDeletable(true));
     User admin = new User();
@@ -473,11 +468,10 @@ class StudyResourceTest extends AbstractTestHelper {
     admin.setUserId(study.getCreateUserId());
     when(datasetService.getStudyWithDatasetsById(admin, study.getStudyId())).thenReturn(study);
     when(userService.findUserByEmail(any())).thenReturn(admin);
-    when(elasticSearchService.deleteIndex(any(), any())).thenThrow(new IOException());
+    doThrow(new RuntimeException()).when(datasetService).deleteStudy(study, admin);
 
     try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, atLeastOnce()).deleteIndex(any(), any());
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -572,6 +572,24 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testDeleteStudyDeletesEachDatasetFromIndex() throws Exception {
+    Study study = new Study();
+    study.setStudyId(1);
+    study.addDatasetIds(Set.of(1, 2));
+    User user = new User();
+    user.setUserId(10);
+    Response response = mock(Response.class);
+    when(response.getStatus()).thenReturn(200);
+    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(response);
+
+    datasetService.deleteStudy(study, user);
+
+    verify(elasticSearchService).deleteIndex(1, user.getUserId());
+    verify(elasticSearchService).deleteIndex(2, user.getUserId());
+    verify(datasetServiceDAO).deleteStudy(study, user);
+  }
+
+  @Test
   void testGetStudyWithDatasetsById() {
     when(studyDAO.findStudyById(anyInt())).thenReturn(new Study());
     assertDoesNotThrow(() -> datasetService.getStudyWithDatasetsById(mockUser, 1));

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -639,6 +639,31 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testDeleteIndexProceedsOnVersionConflicts() throws IOException {
+    String datasetIndexName = randomAlphabetic(10);
+    int datasetId = randomInt(1, 100);
+    int userId = randomInt(1, 100);
+
+    when(esConfig.getDatasetIndexName()).thenReturn(datasetIndexName);
+    mockElasticSearchResponse("{\"deleted\":1}");
+
+    try (var _ = service.deleteIndex(datasetId, userId)) {
+      verify(esClient).performRequest(request.capture());
+      Request capturedRequest = request.getValue();
+      assertEquals("POST", capturedRequest.getMethod());
+      assertEquals("/" + datasetIndexName + "/_delete_by_query", capturedRequest.getEndpoint());
+      assertEquals("proceed", capturedRequest.getParameters().get("conflicts"));
+      assertEquals(
+          """
+              { "query": { "bool": { "must": [ { "match": { "_index": "dataset" } }, { "match": { "_id": "%d" } } ] } } }
+              """
+              .formatted(datasetId),
+          new String(
+              capturedRequest.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
   void testIndexDataset() throws Exception {
     DatasetRecord datasetRecord = createDatasetRecord();
     Dataset dataset1 = datasetRecord.dataset;


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3615

### Summary

This PR:

- Removes duplicate Elasticsearch index deletion from `StudyResource`.
- Keeps study dataset index cleanup in `DatasetService.deleteStudy`.
- Adds `conflicts=proceed` to Elasticsearch delete-by-query requests.
- Adds tests for multi-dataset study index deletion and delete-by-query conflict handling.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
