### PR TITLE
[DT-2869] Add `externalIdentifier` and `externalIdentifierType` to study   

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
@@ -154,6 +154,12 @@ public interface StudyDAO extends Transactional<StudyDAO> {
       """)
   void deleteStudyPropertiesByStudyId(@Bind("studyId") Integer studyId);
 
+  @SqlUpdate(
+      """
+      DELETE FROM study_property WHERE study_id = :studyId AND key = :key
+      """)
+  void deleteStudyPropertyByKey(@Bind("studyId") Integer studyId, @Bind("key") String key);
+
   @UseRowReducer(StudyReducer.class)
   @SqlQuery(
       """

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -10,7 +10,9 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.collections4.CollectionUtils;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.StudyType;
@@ -140,27 +142,11 @@ public record StudyPatch(
   }
 
   private boolean checkPhenotypeIndication(Study study) {
-    Optional<StudyProperty> phenoProp =
-        study.getProperties().stream()
-            .filter(p -> p.getKey().equals(PHENOTYPE_INDICATION))
-            .findFirst();
-    if (phenotypeIndication() != null) {
-      return phenoProp
-          .map(studyProperty -> !phenotypeIndication().equals(studyProperty.getValue()))
-          .orElse(true);
-    }
-    return false;
+    return checkStringProperty(study, PHENOTYPE_INDICATION, phenotypeIndication());
   }
 
   private boolean checkSpecies(Study study) {
-    Optional<StudyProperty> speciesProp =
-        study.getProperties().stream().filter(p -> p.getKey().equals(SPECIES_KEY)).findFirst();
-    if (species() != null) {
-      return speciesProp
-          .map(studyProperty -> !species().equals(studyProperty.getValue()))
-          .orElse(true);
-    }
-    return false;
+    return checkStringProperty(study, SPECIES_KEY, species());
   }
 
   private boolean checkPiName(Study study) {
@@ -191,35 +177,17 @@ public record StudyPatch(
   }
 
   private boolean checkTargetDate(Study study) {
-    Optional<StudyProperty> targetDateProp =
-        study.getProperties().stream()
-            .filter(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE))
-            .findFirst();
-    if (alternativeDataSharingPlanTargetDeliveryDate() != null) {
-      return targetDateProp
-          .map(
-              studyProperty ->
-                  !alternativeDataSharingPlanTargetDeliveryDate().equals(studyProperty.getValue()))
-          .orElse(true);
-    }
-    return false;
+    return checkStringProperty(
+        study,
+        ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE,
+        alternativeDataSharingPlanTargetDeliveryDate());
   }
 
   private boolean checkTargetReleaseDate(Study study) {
-    Optional<StudyProperty> targetReleaseProp =
-        study.getProperties().stream()
-            .filter(
-                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE))
-            .findFirst();
-    if (alternativeDataSharingPlanTargetPublicReleaseDate() != null) {
-      return targetReleaseProp
-          .map(
-              studyProperty ->
-                  !alternativeDataSharingPlanTargetPublicReleaseDate()
-                      .equals(studyProperty.getValue()))
-          .orElse(true);
-    }
-    return false;
+    return checkStringProperty(
+        study,
+        ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE,
+        alternativeDataSharingPlanTargetPublicReleaseDate());
   }
 
   private boolean checkPublicVisibility(Study study) {
@@ -227,26 +195,36 @@ public record StudyPatch(
   }
 
   private boolean checkExternalIdentifier(Study study) {
-    Optional<StudyProperty> prop =
-        study.getProperties().stream()
-            .filter(p -> p.getKey().equals(EXTERNAL_IDENTIFIER))
-            .findFirst();
-    if (externalIdentifier() != null) {
-      return prop.map(studyProperty -> !externalIdentifier().equals(studyProperty.getValue()))
-          .orElse(true);
-    }
-    return false;
+    return checkStringProperty(study, EXTERNAL_IDENTIFIER, externalIdentifier());
   }
 
   private boolean checkExternalIdentifierType(Study study) {
+    return checkStringProperty(study, EXTERNAL_IDENTIFIER_TYPE, externalIdentifierType());
+  }
+
+  // null=no-op, blank=delete (patchable if property exists), non-blank=upsert
+  private boolean checkStringProperty(Study study, String key, String patchValue) {
+    if (patchValue == null) return false;
     Optional<StudyProperty> prop =
-        study.getProperties().stream()
-            .filter(p -> p.getKey().equals(EXTERNAL_IDENTIFIER_TYPE))
-            .findFirst();
-    if (externalIdentifierType() != null) {
-      return prop.map(studyProperty -> !externalIdentifierType().equals(studyProperty.getValue()))
-          .orElse(true);
-    }
-    return false;
+        study.getProperties().stream().filter(p -> p.getKey().equals(key)).findFirst();
+    if (patchValue.isBlank()) return prop.isPresent();
+    return prop.map(p -> !patchValue.equals(p.getValue())).orElse(true);
+  }
+
+  // Returns all optional string-typed study properties from this patch (null values included).
+  // null=no-op, blank=delete, non-blank=upsert
+  public Map<String, String> stringPatchProps() {
+    Map<String, String> props = new HashMap<>();
+    props.put(PHENOTYPE_INDICATION, phenotypeIndication());
+    props.put(SPECIES_KEY, species());
+    props.put(
+        ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE,
+        alternativeDataSharingPlanTargetDeliveryDate());
+    props.put(
+        ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE,
+        alternativeDataSharingPlanTargetPublicReleaseDate());
+    props.put(EXTERNAL_IDENTIFIER, externalIdentifier());
+    props.put(EXTERNAL_IDENTIFIER_TYPE, externalIdentifierType());
+    return props;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -28,7 +28,9 @@ public record StudyPatch(
     List<String> dataCustodianEmail,
     String alternativeDataSharingPlanTargetDeliveryDate,
     String alternativeDataSharingPlanTargetPublicReleaseDate,
-    Boolean publicVisibility) {
+    Boolean publicVisibility,
+    String externalIdentifier,
+    String externalIdentifierType) {
 
   public static final String STUDY_TYPE = "studyType";
   public static final String PHENOTYPE_INDICATION = "phenotypeIndication";
@@ -39,6 +41,8 @@ public record StudyPatch(
       "alternativeDataSharingPlanTargetDeliveryDate";
   public static final String ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE =
       "alternativeDataSharingPlanTargetPublicReleaseDate";
+  public static final String EXTERNAL_IDENTIFIER = "externalIdentifier";
+  public static final String EXTERNAL_IDENTIFIER_TYPE = "externalIdentifierType";
 
   public static StudyPatch fromJson(String json) {
     ObjectMapper mapper = new ObjectMapper();
@@ -104,6 +108,8 @@ public record StudyPatch(
     checks.add(checkTargetDate(study));
     checks.add(checkTargetReleaseDate(study));
     checks.add(checkPublicVisibility(study));
+    checks.add(checkExternalIdentifier(study));
+    checks.add(checkExternalIdentifierType(study));
     return checks.stream().anyMatch(Boolean::booleanValue);
   }
 
@@ -218,5 +224,29 @@ public record StudyPatch(
 
   private boolean checkPublicVisibility(Study study) {
     return publicVisibility() != null && !publicVisibility().equals(study.getPublicVisibility());
+  }
+
+  private boolean checkExternalIdentifier(Study study) {
+    Optional<StudyProperty> prop =
+        study.getProperties().stream()
+            .filter(p -> p.getKey().equals(EXTERNAL_IDENTIFIER))
+            .findFirst();
+    if (externalIdentifier() != null) {
+      return prop.map(studyProperty -> !externalIdentifier().equals(studyProperty.getValue()))
+          .orElse(true);
+    }
+    return false;
+  }
+
+  private boolean checkExternalIdentifierType(Study study) {
+    Optional<StudyProperty> prop =
+        study.getProperties().stream()
+            .filter(p -> p.getKey().equals(EXTERNAL_IDENTIFIER_TYPE))
+            .findFirst();
+    if (externalIdentifierType() != null) {
+      return prop.map(studyProperty -> !externalIdentifierType().equals(studyProperty.getValue()))
+          .orElse(true);
+    }
+    return false;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
@@ -64,7 +64,9 @@ import java.util.Map;
   "alternativeDataSharingPlanAccessManagement",
   "consentGroups",
   "assets",
-  "data"
+  "data",
+  "externalIdentifier",
+  "externalIdentifierType"
 })
 public class DatasetRegistrationSchemaV1 {
 
@@ -112,6 +114,16 @@ public class DatasetRegistrationSchemaV1 {
   @JsonProperty("piEmail")
   @JsonPropertyDescription("Principal Investigator Email")
   private String piEmail;
+
+  /** External Identifier */
+  @JsonProperty("externalIdentifier")
+  @JsonPropertyDescription("External Identifier")
+  private String externalIdentifier;
+
+  /** External Identifier Type */
+  @JsonProperty("externalIdentifierType")
+  @JsonPropertyDescription("External Identifier Type")
+  private String externalIdentifierType;
 
   /** The user creating the dataset submission (Required) */
   @JsonProperty("dataSubmitterUserId")
@@ -395,6 +407,30 @@ public class DatasetRegistrationSchemaV1 {
   @JsonProperty("piEmail")
   public void setPiEmail(String piEmail) {
     this.piEmail = piEmail;
+  }
+
+  /** External Identifier */
+  @JsonProperty("externalIdentifier")
+  public String getExternalIdentifier() {
+    return externalIdentifier;
+  }
+
+  /** External Identifier */
+  @JsonProperty("externalIdentifier")
+  public void setExternalIdentifier(String externalIdentifier) {
+    this.externalIdentifier = externalIdentifier;
+  }
+
+  /** External Identifier Type */
+  @JsonProperty("externalIdentifierType")
+  public String getExternalIdentifierType() {
+    return externalIdentifierType;
+  }
+
+  /** External Identifier Type */
+  @JsonProperty("externalIdentifierType")
+  public void setExternalIdentifierType(String externalIdentifierType) {
+    this.externalIdentifierType = externalIdentifierType;
   }
 
   /** The user creating the dataset submission (Required) */
@@ -860,6 +896,14 @@ public class DatasetRegistrationSchemaV1 {
     sb.append("piEmail");
     sb.append('=');
     sb.append(((this.piEmail == null) ? "<null>" : this.piEmail));
+    sb.append(',');
+    sb.append("externalIdentifier");
+    sb.append('=');
+    sb.append(((this.externalIdentifier == null) ? "<null>" : this.externalIdentifier));
+    sb.append(',');
+    sb.append("externalIdentifierType");
+    sb.append('=');
+    sb.append(((this.externalIdentifierType == null) ? "<null>" : this.externalIdentifierType));
     sb.append(',');
     sb.append("dataSubmitterUserId");
     sb.append('=');

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
@@ -75,6 +75,8 @@ public class DatasetRegistrationSchemaV1Builder {
   public static final String numberOfParticipants = "numberOfParticipants";
   public static final String fileTypes = "fileTypes";
   public static final String throughBioId = "throughBioId";
+  public static final String externalIdentifier = "externalIdentifier";
+  public static final String externalIdentifierType = "externalIdentifierType";
 
   public DatasetRegistrationSchemaV1 build(Study study, List<Dataset> datasets) {
     DatasetRegistrationSchemaV1 schema = new SchemaFromStudy().build(study);

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/SchemaFromStudy.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/SchemaFromStudy.java
@@ -17,6 +17,8 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dbGaPPhsID;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dbGaPStudyRegistrationName;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.embargoReleaseDate;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.externalIdentifier;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.externalIdentifierType;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.multiCenterStudy;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.nihAnvilUse;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.nihGenomicProgramAdministratorName;
@@ -139,6 +141,10 @@ public class SchemaFromStudy {
       }
       schemaV1.setAssets(findMapPropValue(study.getProperties(), assets));
       schemaV1.setData(findMapPropValue(study.getProperties(), data));
+      schemaV1.setExternalIdentifier(
+          findStringPropValue(study.getProperties(), externalIdentifier));
+      schemaV1.setExternalIdentifierType(
+          findStringPropValue(study.getProperties(), externalIdentifierType));
     }
 
     return schemaV1;

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/StudyTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/StudyTerm.java
@@ -20,6 +20,8 @@ public class StudyTerm {
   private List<String> dataTypes;
   private Map<String, Object> assets;
   private Map<String, Object> data;
+  private String externalIdentifier;
+  private String externalIdentifierType;
 
   public String getDescription() {
     return description;
@@ -139,5 +141,21 @@ public class StudyTerm {
 
   public void setData(Map<String, Object> data) {
     this.data = data;
+  }
+
+  public String getExternalIdentifier() {
+    return externalIdentifier;
+  }
+
+  public void setExternalIdentifier(String externalIdentifier) {
+    this.externalIdentifier = externalIdentifier;
+  }
+
+  public String getExternalIdentifierType() {
+    return externalIdentifierType;
+  }
+
+  public void setExternalIdentifierType(String externalIdentifierType) {
+    this.externalIdentifierType = externalIdentifierType;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -782,7 +782,15 @@ public class DatasetRegistrationService implements ConsentLogger {
                       return GsonUtil.getInstance().toJson(registration.getData());
                     }
                     return null;
-                  }));
+                  }),
+              new StudyPropertyExtractor(
+                  "externalIdentifier",
+                  PropertyType.String,
+                  DatasetRegistrationSchemaV1::getExternalIdentifier),
+              new StudyPropertyExtractor(
+                  "externalIdentifierType",
+                  PropertyType.String,
+                  DatasetRegistrationSchemaV1::getExternalIdentifierType));
 
   private static final List<DatasetPropertyExtractor>
       DATASET_REGISTRATION_V1_DATASET_PROPERTY_EXTRACTORS =

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER;
+import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER_TYPE;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.assets;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
 
@@ -294,9 +296,9 @@ public class ElasticSearchService implements ConsentLogger {
         .ifPresent(prop -> term.setAssets(buildMapFromPropertyValue(prop.getValue())));
     findStudyProperty(study.getProperties(), data)
         .ifPresent(prop -> term.setData(buildMapFromPropertyValue(prop.getValue())));
-    findStudyProperty(study.getProperties(), "externalIdentifier")
+    findStudyProperty(study.getProperties(), EXTERNAL_IDENTIFIER)
         .ifPresent(prop -> term.setExternalIdentifier(prop.getValue().toString()));
-    findStudyProperty(study.getProperties(), "externalIdentifierType")
+    findStudyProperty(study.getProperties(), EXTERNAL_IDENTIFIER_TYPE)
         .ifPresent(prop -> term.setExternalIdentifierType(prop.getValue().toString()));
     return term;
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -294,6 +294,10 @@ public class ElasticSearchService implements ConsentLogger {
         .ifPresent(prop -> term.setAssets(buildMapFromPropertyValue(prop.getValue())));
     findStudyProperty(study.getProperties(), data)
         .ifPresent(prop -> term.setData(buildMapFromPropertyValue(prop.getValue())));
+    findStudyProperty(study.getProperties(), "externalIdentifier")
+        .ifPresent(prop -> term.setExternalIdentifier(prop.getValue().toString()));
+    findStudyProperty(study.getProperties(), "externalIdentifierType")
+        .ifPresent(prop -> term.setExternalIdentifierType(prop.getValue().toString()));
     return term;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -3,6 +3,8 @@ package org.broadinstitute.consent.http.service.dao;
 import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE;
 import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE;
 import static org.broadinstitute.consent.http.models.StudyPatch.DATA_CUSTODIAN_EMAIL;
+import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER;
+import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER_TYPE;
 import static org.broadinstitute.consent.http.models.StudyPatch.PHENOTYPE_INDICATION;
 import static org.broadinstitute.consent.http.models.StudyPatch.SPECIES_KEY;
 import static org.broadinstitute.consent.http.models.StudyPatch.STUDY_TYPE;
@@ -499,6 +501,15 @@ public class DatasetServiceDAO implements ConsentLogger {
               ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE,
               patch.alternativeDataSharingPlanTargetPublicReleaseDate(),
               PropertyType.String));
+    }
+    if (patch.externalIdentifier() != null) {
+      studyUpdate.props.add(
+          new StudyProperty(EXTERNAL_IDENTIFIER, patch.externalIdentifier(), PropertyType.String));
+    }
+    if (patch.externalIdentifierType() != null) {
+      studyUpdate.props.add(
+          new StudyProperty(
+              EXTERNAL_IDENTIFIER_TYPE, patch.externalIdentifierType(), PropertyType.String));
     }
     return studyUpdate;
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -1,12 +1,6 @@
 package org.broadinstitute.consent.http.service.dao;
 
-import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE;
-import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE;
 import static org.broadinstitute.consent.http.models.StudyPatch.DATA_CUSTODIAN_EMAIL;
-import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER;
-import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER_TYPE;
-import static org.broadinstitute.consent.http.models.StudyPatch.PHENOTYPE_INDICATION;
-import static org.broadinstitute.consent.http.models.StudyPatch.SPECIES_KEY;
 import static org.broadinstitute.consent.http.models.StudyPatch.STUDY_TYPE;
 
 import com.google.inject.Inject;
@@ -444,6 +438,8 @@ public class DatasetServiceDAO implements ConsentLogger {
           StudyUpdate studyUpdate = convertToStudyUpdate(study, user, patch);
           try {
             executeUpdateStudyKeepProps(handle, studyUpdate);
+            // Blank string signals intent to remove the property
+            deleteBlankPatchedStudyProps(handle, study.getStudyId(), patch);
           } catch (Exception e) {
             handle.rollback();
             logException(e);
@@ -452,6 +448,18 @@ public class DatasetServiceDAO implements ConsentLogger {
           handle.commit();
         });
     return studyDAO.findStudyById(study.getStudyId());
+  }
+
+  private void deleteBlankPatchedStudyProps(Handle handle, Integer studyId, StudyPatch patch) {
+    StudyDAO studyDAOLocal = handle.attach(StudyDAO.class);
+    patch
+        .stringPatchProps()
+        .forEach(
+            (key, value) -> {
+              if (value != null && value.isBlank()) {
+                studyDAOLocal.deleteStudyPropertyByKey(studyId, key);
+              }
+            });
   }
 
   // Helper method to convert StudyPatch to StudyUpdate
@@ -473,14 +481,6 @@ public class DatasetServiceDAO implements ConsentLogger {
     if (patch.studyType() != null) {
       studyUpdate.props.add(new StudyProperty(STUDY_TYPE, patch.studyType(), PropertyType.String));
     }
-    if (patch.phenotypeIndication() != null) {
-      studyUpdate.props.add(
-          new StudyProperty(
-              PHENOTYPE_INDICATION, patch.phenotypeIndication(), PropertyType.String));
-    }
-    if (patch.species() != null) {
-      studyUpdate.props.add(new StudyProperty(SPECIES_KEY, patch.species(), PropertyType.String));
-    }
     if (patch.dataCustodianEmail() != null) {
       studyUpdate.props.add(
           new StudyProperty(
@@ -488,29 +488,14 @@ public class DatasetServiceDAO implements ConsentLogger {
               GsonUtil.getInstance().toJson(patch.dataCustodianEmail()),
               PropertyType.Json));
     }
-    if (patch.alternativeDataSharingPlanTargetDeliveryDate() != null) {
-      studyUpdate.props.add(
-          new StudyProperty(
-              ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE,
-              patch.alternativeDataSharingPlanTargetDeliveryDate(),
-              PropertyType.String));
-    }
-    if (patch.alternativeDataSharingPlanTargetPublicReleaseDate() != null) {
-      studyUpdate.props.add(
-          new StudyProperty(
-              ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE,
-              patch.alternativeDataSharingPlanTargetPublicReleaseDate(),
-              PropertyType.String));
-    }
-    if (patch.externalIdentifier() != null) {
-      studyUpdate.props.add(
-          new StudyProperty(EXTERNAL_IDENTIFIER, patch.externalIdentifier(), PropertyType.String));
-    }
-    if (patch.externalIdentifierType() != null) {
-      studyUpdate.props.add(
-          new StudyProperty(
-              EXTERNAL_IDENTIFIER_TYPE, patch.externalIdentifierType(), PropertyType.String));
-    }
+    patch
+        .stringPatchProps()
+        .forEach(
+            (key, value) -> {
+              if (value != null && !value.isBlank()) {
+                studyUpdate.props.add(new StudyProperty(key, value, PropertyType.String));
+              }
+            });
     return studyUpdate;
   }
 

--- a/src/main/resources/assets/schemas/DatasetRegistrationSchemaV1.yaml
+++ b/src/main/resources/assets/schemas/DatasetRegistrationSchemaV1.yaml
@@ -211,6 +211,12 @@ properties:
     type: object
     title: DatasetRegistrationSchemaV1Assets
     description: Study Assets
+  externalIdentifier:
+    type: string
+    description: The identifier for this study in an external system (e.g. SCP1671 in Single Cell Portal)
+  externalIdentifierType:
+    type: string
+    description: The name of the external system the identifier belongs to (e.g. Single Cell Portal)
 required:
   - studyName
   - studyDescription

--- a/src/main/resources/assets/schemas/StudyPatch.yaml
+++ b/src/main/resources/assets/schemas/StudyPatch.yaml
@@ -36,3 +36,9 @@ properties:
   publicVisibility:
     type: boolean
     description: Whether this study is publicly visible or not.
+  externalIdentifier:
+    type: string
+    description: The identifier for this study in an external system (e.g. SCP1671 in Single Cell Portal).
+  externalIdentifierType:
+    type: string
+    description: The name of the external system the identifier belongs to (e.g. Single Cell Portal).

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -376,6 +376,20 @@ class StudyDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testDeleteStudyPropertyByKey() {
+    Study study = insertStudyWithProperties();
+    Integer id = study.getStudyId();
+    studyDAO.insertStudyProperty(id, "toDelete", PropertyType.String.toString(), "value");
+    studyDAO.insertStudyProperty(id, "toKeep", PropertyType.String.toString(), "value");
+
+    studyDAO.deleteStudyPropertyByKey(id, "toDelete");
+
+    Study found = studyDAO.findStudyById(id);
+    assertTrue(found.getProperties().stream().noneMatch(p -> p.getKey().equals("toDelete")));
+    assertTrue(found.getProperties().stream().anyMatch(p -> p.getKey().equals("toKeep")));
+  }
+
+  @Test
   void testFindStudyByName() {
     Study study = insertStudyWithProperties();
     Study foundStudy = studyDAO.findStudyByName(study.getName());

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
@@ -18,6 +18,8 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dbGaPPhsID;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dbGaPStudyRegistrationName;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.embargoReleaseDate;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.externalIdentifier;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.externalIdentifierType;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.fileTypes;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.generalResearchUse;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.multiCenterStudy;
@@ -126,6 +128,8 @@ class DatasetRegistrationSchemaV1BuilderTest {
     assertNotNull(schemaV1.getAlternativeDataSharingPlanTargetDeliveryDate());
     assertNotNull(schemaV1.getAlternativeDataSharingPlanTargetPublicReleaseDate());
     assertNotNull(schemaV1.getAlternativeDataSharingPlanAccessManagement());
+    assertNotNull(schemaV1.getExternalIdentifier());
+    assertNotNull(schemaV1.getExternalIdentifierType());
   }
 
   @Test
@@ -364,6 +368,12 @@ class DatasetRegistrationSchemaV1BuilderTest {
             PropertyType.String));
     study.addProperty(
         createStudyProperty(throughBioId, study.getStudyId(), randomString(), PropertyType.String));
+    study.addProperty(
+        createStudyProperty(
+            externalIdentifier, study.getStudyId(), randomString(), PropertyType.String));
+    study.addProperty(
+        createStudyProperty(
+            externalIdentifierType, study.getStudyId(), randomString(), PropertyType.String));
   }
 
   private String randomString() {

--- a/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
@@ -43,7 +43,8 @@ class StudyPatchTest extends AbstractTestHelper {
   void testIsPatchableNoValues() {
     Study study = mockStudy();
     StudyPatch patch =
-        new StudyPatch(null, null, null, null, null, null, null, null, null, null, null, null);
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     assertFalse(patch.isPatchable(study));
   }
 
@@ -63,7 +64,9 @@ class StudyPatchTest extends AbstractTestHelper {
             List.of("EMAIL1", "EMAIL2"),
             "01/01/2020",
             "01/01/2020",
-            mockStudy.getPublicVisibility());
+            mockStudy.getPublicVisibility(),
+            null,
+            null);
     assertFalse(patch.isPatchable(mockStudy));
   }
 
@@ -71,7 +74,8 @@ class StudyPatchTest extends AbstractTestHelper {
   void testIsPatchableName() {
     Study study = mockStudy();
     StudyPatch patch =
-        new StudyPatch("Name", null, null, null, null, null, null, null, null, null, null, null);
+        new StudyPatch(
+            "Name", null, null, null, null, null, null, null, null, null, null, null, null, null);
     assertTrue(patch.isPatchable(study));
   }
 
@@ -80,7 +84,20 @@ class StudyPatchTest extends AbstractTestHelper {
     Study study = mockStudy();
     StudyPatch patch =
         new StudyPatch(
-            null, StudyType.ANALYTICAL, null, null, null, null, null, null, null, null, null, null);
+            null,
+            StudyType.ANALYTICAL,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertTrue(patch.isPatchable(study));
   }
 
@@ -89,7 +106,20 @@ class StudyPatchTest extends AbstractTestHelper {
     Study study = mockStudy();
     StudyPatch patch =
         new StudyPatch(
-            null, null, "Description", null, null, null, null, null, null, null, null, null);
+            null,
+            null,
+            "Description",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertTrue(patch.isPatchable(study));
   }
 
@@ -109,6 +139,8 @@ class StudyPatchTest extends AbstractTestHelper {
             null,
             null,
             null,
+            null,
+            null,
             null);
     assertTrue(patch.isPatchable(study));
   }
@@ -118,7 +150,20 @@ class StudyPatchTest extends AbstractTestHelper {
     Study study = mockStudy();
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, "New Phenotype", null, null, null, null, null, null, null);
+            null,
+            null,
+            null,
+            null,
+            "New Phenotype",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertTrue(patch.isPatchable(study));
   }
 
@@ -127,7 +172,20 @@ class StudyPatchTest extends AbstractTestHelper {
     Study study = mockStudy();
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, null, "New Species", null, null, null, null, null, null);
+            null,
+            null,
+            null,
+            null,
+            null,
+            "New Species",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertTrue(patch.isPatchable(study));
   }
 
@@ -136,7 +194,20 @@ class StudyPatchTest extends AbstractTestHelper {
     Study study = mockStudy();
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, null, null, "New PI Name", null, null, null, null, null);
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "New PI Name",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertTrue(patch.isPatchable(study));
   }
 
@@ -145,7 +216,20 @@ class StudyPatchTest extends AbstractTestHelper {
     Study study = mockStudy();
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, null, null, null, "New PI Email", null, null, null, null);
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "New PI Email",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertTrue(patch.isPatchable(study));
   }
 
@@ -165,6 +249,8 @@ class StudyPatchTest extends AbstractTestHelper {
             List.of("new_email1", "new_email2"),
             null,
             null,
+            null,
+            null,
             null);
     assertTrue(patch.isPatchable(study));
   }
@@ -174,7 +260,20 @@ class StudyPatchTest extends AbstractTestHelper {
     Study study = mockStudy();
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, null, null, null, null, null, "New Date", null, null);
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "New Date",
+            null,
+            null,
+            null,
+            null);
     assertTrue(patch.isPatchable(study));
   }
 
@@ -183,7 +282,20 @@ class StudyPatchTest extends AbstractTestHelper {
     Study study = mockStudy();
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, null, null, null, null, null, null, "New Date", null);
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "New Date",
+            null,
+            null,
+            null);
     assertTrue(patch.isPatchable(study));
   }
 
@@ -191,7 +303,40 @@ class StudyPatchTest extends AbstractTestHelper {
   void testIsPatchablePublicVisibility() {
     Study study = mockStudy();
     StudyPatch patch =
-        new StudyPatch(null, null, null, null, null, null, null, null, null, null, null, false);
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, false, null, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableExternalIdentifier() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, "SCP1671",
+            null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableExternalIdentifierType() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "Single Cell Portal");
     assertTrue(patch.isPatchable(study));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
@@ -425,6 +425,49 @@ class StudyPatchTest extends AbstractTestHelper {
     assertFalse(patch.isPatchable(study));
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "   "})
+  void testIsPatchableExternalIdentifierBlankIsFalseWhenPropertyAbsent(String blank) {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, blank, null);
+    assertFalse(patch.isPatchable(study));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "   "})
+  void testIsPatchableExternalIdentifierBlankIsTrueWhenPropertyExists(String blank) {
+    Study study = mockStudy();
+    study.addProperty(new StudyProperty(EXTERNAL_IDENTIFIER, "SCP1671", PropertyType.String));
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, blank, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "   "})
+  void testIsPatchableExternalIdentifierTypeBlankIsFalseWhenPropertyAbsent(String blank) {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, null, blank);
+    assertFalse(patch.isPatchable(study));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "   "})
+  void testIsPatchableExternalIdentifierTypeBlankIsTrueWhenPropertyExists(String blank) {
+    Study study = mockStudy();
+    study.addProperty(
+        new StudyProperty(EXTERNAL_IDENTIFIER_TYPE, "Single Cell Portal", PropertyType.String));
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, null, blank);
+    assertTrue(patch.isPatchable(study));
+  }
+
   @Test
   void testFromJsonExternalIdentifierFields() {
     String json =

--- a/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
@@ -3,9 +3,12 @@ package org.broadinstitute.consent.http.models;
 import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE;
 import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE;
 import static org.broadinstitute.consent.http.models.StudyPatch.DATA_CUSTODIAN_EMAIL;
+import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER;
+import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER_TYPE;
 import static org.broadinstitute.consent.http.models.StudyPatch.PHENOTYPE_INDICATION;
 import static org.broadinstitute.consent.http.models.StudyPatch.SPECIES_KEY;
 import static org.broadinstitute.consent.http.models.StudyPatch.STUDY_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -338,6 +341,97 @@ class StudyPatchTest extends AbstractTestHelper {
             null,
             "Single Cell Portal");
     assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableExternalIdentifierDifferentValue() {
+    Study study = mockStudy();
+    study.addProperty(new StudyProperty(EXTERNAL_IDENTIFIER, "OLD_ID", PropertyType.String));
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, "NEW_ID", null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableSameExternalIdentifier() {
+    Study study = mockStudy();
+    String existingValue = randomAlphabetic(10);
+    study.addProperty(new StudyProperty(EXTERNAL_IDENTIFIER, existingValue, PropertyType.String));
+    StudyPatch patch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            existingValue,
+            null);
+    assertFalse(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableExternalIdentifierTypeDifferentValue() {
+    Study study = mockStudy();
+    study.addProperty(new StudyProperty(EXTERNAL_IDENTIFIER_TYPE, "Old Type", PropertyType.String));
+    StudyPatch patch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "New Type");
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableSameExternalIdentifierType() {
+    Study study = mockStudy();
+    String existingValue = randomAlphabetic(10);
+    study.addProperty(
+        new StudyProperty(EXTERNAL_IDENTIFIER_TYPE, existingValue, PropertyType.String));
+    StudyPatch patch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            existingValue);
+    assertFalse(patch.isPatchable(study));
+  }
+
+  @Test
+  void testFromJsonExternalIdentifierFields() {
+    String json =
+        "{\"externalIdentifier\": \"SCP1671\", \"externalIdentifierType\": \"Single Cell Portal\"}";
+    StudyPatch patch = StudyPatch.fromJson(json);
+    assertEquals("SCP1671", patch.externalIdentifier());
+    assertEquals("Single Cell Portal", patch.externalIdentifierType());
   }
 
   private Study mockStudy() {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -303,6 +303,9 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
         studyProps,
         "assets",
         PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getAssets())));
+    assertContainsStudyProperty(studyProps, "externalIdentifier", schema.getExternalIdentifier());
+    assertContainsStudyProperty(
+        studyProps, "externalIdentifierType", schema.getExternalIdentifierType());
 
     List<DatasetProperty> datasetProps = inserts.getFirst().props();
     assertContainsDatasetProperty(
@@ -1343,6 +1346,8 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
     consentGroup.setDataLocation(ConsentGroup.DataLocation.TDR_LOCATION);
     consentGroup.setDataAccessCommitteeId(new Random().nextInt());
     schemaV1.setAssets(Map.of("key", List.of("value1", "value2")));
+    schemaV1.setExternalIdentifier(randomAlphabetic(10));
+    schemaV1.setExternalIdentifierType(randomAlphabetic(10));
     schemaV1.setConsentGroups(List.of(consentGroup));
     return schemaV1;
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -1097,7 +1097,9 @@ class DatasetServiceTest extends AbstractTestHelper {
             null,
             null,
             null,
-            true);
+            true,
+            null,
+            null);
     when(datasetServiceDAO.patchStudy(study, user, patch)).thenReturn(study);
     when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
     assertDoesNotThrow(() -> datasetService.patchStudy(study.getStudyId(), user, patch));
@@ -1534,7 +1536,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setUserId(1);
     StudyPatch patch =
-        new StudyPatch(null, null, null, null, null, null, null, null, null, null, null, null);
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 
     when(studyDAO.findStudyById(1)).thenReturn(study);
     when(datasetServiceDAO.patchStudy(any(), any(), any()))

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -239,7 +239,9 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         createStudyProperty("phenotypeIndication", PropertyType.String),
         createStudyProperty("species", PropertyType.String),
         createStudyProperty("dataCustodianEmail", PropertyType.Json),
-        createStudyProperty("throughBioId", PropertyType.String));
+        createStudyProperty("throughBioId", PropertyType.String),
+        createStudyProperty("externalIdentifier", PropertyType.String),
+        createStudyProperty("externalIdentifierType", PropertyType.String));
     Dataset dataset = createDataset(user, updateUser, new DataUse(), dac);
     dataset.setProperties(
         Set.of(
@@ -359,6 +361,22 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
             .filter(p -> p.getKey().equals("throughBioId"))
             .findFirst();
     assertTrue(throughBioIdProp.isPresent());
+    Optional<StudyProperty> externalIdentifierProp =
+        datasetRecord.study.getProperties().stream()
+            .filter(p -> p.getKey().equals("externalIdentifier"))
+            .findFirst();
+    assertTrue(externalIdentifierProp.isPresent());
+    assertEquals(
+        externalIdentifierProp.get().getValue().toString(),
+        term.getStudy().getExternalIdentifier());
+    Optional<StudyProperty> externalIdentifierTypeProp =
+        datasetRecord.study.getProperties().stream()
+            .filter(p -> p.getKey().equals("externalIdentifierType"))
+            .findFirst();
+    assertTrue(externalIdentifierTypeProp.isPresent());
+    assertEquals(
+        externalIdentifierTypeProp.get().getValue().toString(),
+        term.getStudy().getExternalIdentifierType());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -1785,6 +1785,125 @@ class DatasetServiceDAOTest extends DAOTestHelper {
             .getValue());
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "   "})
+  void testPatchStudyExternalIdentifierBlankIsIgnored(String blank) throws Exception {
+    Study study = createStudy(null, null, null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, blank, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertTrue(
+        patched.getProperties().stream().noneMatch(p -> p.getKey().equals(EXTERNAL_IDENTIFIER)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "   "})
+  void testPatchStudyExternalIdentifierTypeBlankIsIgnored(String blank) throws Exception {
+    Study study = createStudy(null, null, null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, null, blank);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertTrue(
+        patched.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(EXTERNAL_IDENTIFIER_TYPE)));
+  }
+
+  @Test
+  void testPatchStudyExternalIdentifierRemoval() throws Exception {
+    Study study = createStudy(null, null, null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    // First set a value
+    StudyPatch setPatch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10),
+            null);
+    serviceDAO.patchStudy(study, user, setPatch);
+    // Then remove it with a blank string
+    StudyPatch removePatch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, "", null);
+    Study patched = serviceDAO.patchStudy(study, user, removePatch);
+    assertTrue(
+        patched.getProperties().stream().noneMatch(p -> p.getKey().equals(EXTERNAL_IDENTIFIER)));
+  }
+
+  @Test
+  void testPatchStudyExternalIdentifierTypeRemoval() throws Exception {
+    Study study = createStudy(null, null, null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    // First set a value
+    StudyPatch setPatch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10));
+    serviceDAO.patchStudy(study, user, setPatch);
+    // Then remove it with a blank string
+    StudyPatch removePatch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, null, "");
+    Study patched = serviceDAO.patchStudy(study, user, removePatch);
+    assertTrue(
+        patched.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(EXTERNAL_IDENTIFIER_TYPE)));
+  }
+
+  @Test
+  void testPatchStudyPhenotypeIndicationRemoval() throws Exception {
+    Study study = createStudy(null, null, null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch setPatch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    serviceDAO.patchStudy(study, user, setPatch);
+    StudyPatch removePatch =
+        new StudyPatch(
+            null, null, null, null, "", null, null, null, null, null, null, null, null, null);
+    Study patched = serviceDAO.patchStudy(study, user, removePatch);
+    assertTrue(
+        patched.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+  }
+
   @Test
   void testUpdateDatasetDataUse() {
     Dataset dataset = createDataset();

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -3,6 +3,8 @@ package org.broadinstitute.consent.http.service.dao;
 import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE;
 import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE;
 import static org.broadinstitute.consent.http.models.StudyPatch.DATA_CUSTODIAN_EMAIL;
+import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER;
+import static org.broadinstitute.consent.http.models.StudyPatch.EXTERNAL_IDENTIFIER_TYPE;
 import static org.broadinstitute.consent.http.models.StudyPatch.PHENOTYPE_INDICATION;
 import static org.broadinstitute.consent.http.models.StudyPatch.SPECIES_KEY;
 import static org.broadinstitute.consent.http.models.StudyPatch.STUDY_TYPE;
@@ -1169,7 +1171,9 @@ class DatasetServiceDAOTest extends DAOTestHelper {
             List.of("email1", "email2"),
             randomAlphabetic(10),
             randomAlphabetic(10),
-            true);
+            true,
+            randomAlphabetic(10),
+            randomAlphabetic(10));
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(patch.name(), patched.getName());
     assertEquals(patch.description(), patched.getDescription());
@@ -1227,7 +1231,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     Study study = createStudy(null, null, null);
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
-        new StudyPatch(null, null, null, null, null, null, null, null, null, null, null, null);
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
     assertEquals(study.getDescription(), patched.getDescription());
@@ -1255,7 +1260,20 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
         new StudyPatch(
-            randomAlphabetic(10), null, null, null, null, null, null, null, null, null, null, null);
+            randomAlphabetic(10),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(patch.name(), patched.getName());
     assertEquals(study.getDescription(), patched.getDescription());
@@ -1283,7 +1301,20 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
         new StudyPatch(
-            null, null, randomAlphabetic(10), null, null, null, null, null, null, null, null, null);
+            null,
+            null,
+            randomAlphabetic(10),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
     assertEquals(patch.description(), patched.getDescription());
@@ -1322,6 +1353,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
             null,
             null,
             null,
+            null,
+            null,
             null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
@@ -1350,7 +1383,20 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, null, null, randomAlphabetic(10), null, null, null, null, null);
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
     assertEquals(study.getDescription(), patched.getDescription());
@@ -1377,7 +1423,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     Study study = createStudy(null, null, null);
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
-        new StudyPatch(null, null, null, null, null, null, null, null, null, null, null, false);
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null, false, null, null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
     assertEquals(study.getDescription(), patched.getDescription());
@@ -1407,6 +1454,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         new StudyPatch(
             null,
             StudyType.COHORT_STUDY,
+            null,
+            null,
             null,
             null,
             null,
@@ -1450,7 +1499,20 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, randomAlphabetic(10), null, null, null, null, null, null, null);
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
     assertEquals(study.getDescription(), patched.getDescription());
@@ -1483,7 +1545,20 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, null, randomAlphabetic(10), null, null, null, null, null, null);
+            null,
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
     assertEquals(study.getDescription(), patched.getDescription());
@@ -1528,6 +1603,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
             List.of("email1", "email2"),
             null,
             null,
+            null,
+            null,
             null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
@@ -1562,7 +1639,20 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, null, null, null, null, null, randomAlphabetic(10), null, null);
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10),
+            null,
+            null,
+            null,
+            null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
     assertEquals(study.getDescription(), patched.getDescription());
@@ -1594,7 +1684,20 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
         new StudyPatch(
-            null, null, null, null, null, null, null, null, null, null, randomAlphabetic(10), null);
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10),
+            null,
+            null,
+            null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
     assertEquals(study.getDescription(), patched.getDescription());
@@ -1615,6 +1718,68 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         patched.getProperties().stream()
             .filter(
                 p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+  }
+
+  @Test
+  void testPatchStudyExternalIdentifier() throws Exception {
+    Study study = createStudy(null, null, null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10),
+            null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(
+        patch.externalIdentifier(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(EXTERNAL_IDENTIFIER))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+  }
+
+  @Test
+  void testPatchStudyExternalIdentifierType() throws Exception {
+    Study study = createStudy(null, null, null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            randomAlphabetic(10));
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(
+        patch.externalIdentifierType(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(EXTERNAL_IDENTIFIER_TYPE))
             .findFirst()
             .orElseThrow()
             .getValue());


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2869

### Summary
                                                                                                                                                                                                                    
  - Adds `externalIdentifier` and `externalIdentifierType` as optional study fields to support linking DUOS studies to pages in external systems (e.g. `SCP1671` → `Single Cell Portal`)                            
  - Both fields are stored as `study_property` entries, consistent with the existing pattern for optional study metadata like `studyType`, `dbGaPPhsID`, etc.                                                       
  - No database migration required                                                                                                                                                                                  
                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  - **`StudyPatch`** — adds the two fields so they can be set via `PATCH /api/dataset/study/{studyId}`                                                                                                              
  - **`DatasetRegistrationSchemaV1` / `DatasetRegistrationSchemaV1Builder`** — adds fields to the registration schema so they flow through `POST /api/dataset/v3` and `PUT /api/dataset/study/{studyId}`            
  - **`DatasetRegistrationService`** — new `StudyPropertyExtractor` entries persist both fields as study properties on create/update                                                                                
  - **`SchemaFromStudy`** — reads the properties back when building a registration schema from a stored study (`GET /api/dataset/study/registration/{studyId}`)                                                     
  - **`DatasetServiceDAO`** — `convertToStudyUpdate` maps patch fields to `StudyProperty` objects                                                                                                                   
  - **`StudyTerm` / `ElasticSearchService`** — indexes both fields as named fields on the ES study document                                                                                                         
  - **`StudyPatch.yaml` / `DatasetRegistrationSchemaV1.yaml`** — OpenAPI schema updates for all affected endpoints    

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
