### PR TITLE
[DT-2840] Consolidate so approval fields

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -93,8 +93,6 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
         as up_property_key, up.property_value AS up_property_value,
         dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id,
         dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id,
-        dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date,
-        dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id,
         dar.requires_so_approval AS dar_requires_so_approval, dar.approving_so_timestamp AS dar_approving_signing_official_approved_date,
         dar.approving_so_id AS dar_approving_signing_official_user_id,
         dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date,
@@ -140,8 +138,6 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           + "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id, "
           + "dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date, "
           + "dar.update_date AS dar_update_date, dar.data AS data, "
-          + "dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date, "
-          + "dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id, "
           + "dar.requires_so_approval AS dar_requires_so_approval, dar.approving_so_timestamp AS dar_approving_signing_official_approved_date,"
           + "dar.approving_so_id AS dar_approving_signing_official_user_id,"
           + "e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date, "
@@ -197,8 +193,6 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
        dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id,
        dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date,
        dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
-       dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date,
-       dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id,
        dar.requires_so_approval AS dar_requires_so_approval, dar.approving_so_timestamp AS dar_approving_signing_official_approved_date,
        dar.approving_so_id AS dar_approving_signing_official_user_id,
        e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date,
@@ -253,8 +247,6 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
        dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id,
        dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date,
        dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
-       dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date,
-       dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id,
        dar.requires_so_approval AS dar_requires_so_approval, dar.approving_so_timestamp AS dar_approving_signing_official_approved_date,
        dar.approving_so_id AS dar_approving_signing_official_user_id,
        e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date,

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -26,10 +26,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       SELECT c.collection_id as dar_collection_id, c.dar_code,
         latest_dar.submission_date, latest_dar.reference_id as latest_dar_reference_id,
         latest_dar.parent_id as latest_dar_parent_id,
-        latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
-        latest_dar.closeout_so_approval_timestamp AS latest_dar_closeout_so_approval_timestamp,
         latest_dar.requires_so_approval as latest_dar_requires_so_approval,
         latest_dar.approving_so_id as latest_dar_so_approver_id,
+        latest_dar.approving_so_timestamp as latest_dar_so_approver_timestamp,
         researcher.display_name as researcher_name, i.institution_name,
         e.election_id, e.status, e.dataset_id, e.reference_id,
         v.vote_id as v_vote_id, dd.dataset_id as dd_datasetid,
@@ -89,8 +88,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         AND (e.latest = e.election_id OR e.election_id IS NULL)
       GROUP BY
         c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
-        latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
-        latest_dar.requires_so_approval, latest_dar.approving_so_id, researcher.display_name, i.institution_name,
+        latest_dar.requires_so_approval, latest_dar.approving_so_id, latest_dar.approving_so_timestamp, researcher.display_name, i.institution_name,
         e.election_id, e.status, e.reference_id, e.dataset_id, v.vote_id, dd.dataset_id, v.user_id,
         v.vote, v.election_id, v.create_date, v.update_date, v.type, latest_dar.data, dac.name
       """)
@@ -108,10 +106,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                latest_dar.submission_date,
                latest_dar.reference_id as latest_dar_reference_id,
                latest_dar.parent_id as latest_dar_parent_id,
-               latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
-               latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
                latest_dar.requires_so_approval as latest_dar_requires_so_approval,
                latest_dar.approving_so_id as latest_dar_so_approver_id,
+               latest_dar.approving_so_timestamp as latest_dar_so_approver_timestamp,
                u.display_name as researcher_name,
                i.institution_name,
                e.election_id,
@@ -155,8 +152,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                 AND (e.latest = e.election_id OR e.election_id IS NULL)
               GROUP BY
               c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
-              latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
-              latest_dar.requires_so_approval, latest_dar.approving_so_id, u.display_name,
+              latest_dar.requires_so_approval, latest_dar.approving_so_id, latest_dar.approving_so_timestamp, u.display_name,
               i.institution_name, e.election_id, e.status, e.reference_id, e.dataset_id,
               dd.dataset_id, latest_dar.data, dac.name
           """)
@@ -175,10 +171,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               latest_dar.submission_date,
               latest_dar.reference_id AS latest_dar_reference_id,
               latest_dar.parent_id AS latest_dar_parent_id,
-              latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
-              latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
               latest_dar.requires_so_approval as latest_dar_requires_so_approval,
               latest_dar.approving_so_id as latest_dar_so_approver_id,
+              latest_dar.approving_so_timestamp as latest_dar_so_approver_timestamp,
               u.display_name AS researcher_name,
               i.institution_name,
               e.election_id,
@@ -215,8 +210,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
           WHERE (e.latest = e.election_id OR e.election_id IS NULL)
           GROUP BY
               c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
-              latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
-              latest_dar.requires_so_approval, latest_dar.approving_so_id, u.display_name,
+              latest_dar.requires_so_approval, latest_dar.approving_so_id, latest_dar.approving_so_timestamp, u.display_name,
               i.institution_name, e.election_id, e.status, e.dataset_id, dd.dataset_id, latest_dar.data, dac.name
       """)
   List<DarCollectionSummary> getDarCollectionSummariesForAdmin();
@@ -233,10 +227,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               latest_dar.submission_date,
               latest_dar.reference_id AS latest_dar_reference_id,
               latest_dar.parent_id AS latest_dar_parent_id,
-              latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
-              latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
               latest_dar.requires_so_approval as latest_dar_requires_so_approval,
               latest_dar.approving_so_id as latest_dar_so_approver_id,
+              latest_dar.approving_so_timestamp as latest_dar_so_approver_timestamp,
               u.display_name AS researcher_name,
               i.institution_name,
               e.election_id,
@@ -281,7 +274,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               AND (e.latest = e.election_id OR e.election_id IS NULL)
           GROUP BY
               c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id, u.display_name, i.institution_name,
-              latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp, latest_dar.requires_so_approval, latest_dar.approving_so_id,
+              latest_dar.requires_so_approval, latest_dar.approving_so_id, latest_dar.approving_so_timestamp,
               e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, latest_dar.data, dac.name
       """)
   List<DarCollectionSummary> getDarCollectionSummariesForResearcher(@Bind("userId") Integer userId);
@@ -295,10 +288,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       """
       SELECT c.collection_id as dar_collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id AS latest_dar_reference_id,
         latest_dar.parent_id AS latest_dar_parent_id,
-        latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
-        latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
         latest_dar.requires_so_approval as latest_dar_requires_so_approval,
         latest_dar.approving_so_id as latest_dar_so_approver_id,
+        latest_dar.approving_so_timestamp as latest_dar_so_approver_timestamp,
         u.display_name as researcher_name, u.user_id as researcher_id,
         i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, v.vote_id as v_vote_id, dd.dataset_id as dd_datasetid,
         v.user_id as v_user_id, v.vote as v_vote, v.election_id as v_election_id, v.create_date as v_create_date, v.update_date as v_update_date, v.type as v_type,
@@ -343,8 +335,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         AND (LOWER(v.type) IN ('final', 'radar_approve') OR (v.user_id = :currentUserId OR v.vote_id IS NULL))
       GROUP BY
         c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
-        latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
-        latest_dar.requires_so_approval, latest_dar.approving_so_id,
+        latest_dar.requires_so_approval, latest_dar.approving_so_id, latest_dar.approving_so_timestamp,
         u.display_name, u.user_id,
         i.institution_name, i.institution_id, e.election_id, e.status,
         e.reference_id, e.dataset_id, v.vote_id, dd.dataset_id, v.user_id,
@@ -363,10 +354,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       """
               SELECT c.collection_id as dar_collection_id, c.dar_code, latest_dar.submission_date,
                 latest_dar.reference_id as latest_dar_reference_id, latest_dar.parent_id as latest_dar_parent_id,
-                latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
-                latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
                 latest_dar.requires_so_approval as latest_dar_requires_so_approval,
                 latest_dar.approving_so_id as latest_dar_so_approver_id,
+                latest_dar.approving_so_timestamp as latest_dar_so_approver_timestamp,
                 u.display_name as researcher_name,
                 u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
                 dac.name AS dac_name,
@@ -404,9 +394,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                 AND (e.latest = e.election_id OR e.election_id IS NULL)
               GROUP BY
                 c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
-                latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
-                latest_dar.requires_so_approval, latest_dar.approving_so_id,
-                latest_dar.requires_so_approval, latest_dar.approving_so_id, u.display_name, u.user_id, i.institution_name,
+                latest_dar.requires_so_approval, latest_dar.approving_so_id, latest_dar.approving_so_timestamp, u.display_name, u.user_id, i.institution_name,
                 i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, latest_dar.data, dac.name
           """)
   DarCollectionSummary getDarCollectionSummaryByCollectionId(

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -42,7 +42,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
           SELECT collection.dar_code, dd.dataset_id, dar.id, dar.reference_id, dar.collection_id,
             dar.parent_id, dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
             dar.data, dar.era_commons_id, dar.admin_dar_notes, dar.approving_so_id, dar.approving_so_timestamp,
-            dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id,
             dar.requires_so_approval
           FROM data_access_request dar
           LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
@@ -72,8 +71,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
         dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
         dar.data,
         dd.dataset_id, collection.dar_code, dar.era_commons_id, dar.admin_dar_notes,
-        dar.approving_so_id, dar.approving_so_timestamp, dar.requires_so_approval,
-        dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
+        dar.approving_so_id, dar.approving_so_timestamp, dar.requires_so_approval
       FROM data_access_request dar
       LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
       INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
@@ -117,7 +115,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id,
         dar.create_date, dar.submission_date, dar.update_date, dar.data, dar.era_commons_id, dar.admin_dar_notes,
         dar.approving_so_id, dar.approving_so_timestamp, dar.requires_so_approval,
-        dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id,
         dd.dataset_id, collection.dar_code
       FROM data_access_request dar
       LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
@@ -145,7 +142,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id,
         dar.create_date, dar.submission_date, dar.update_date, dar.data, dar.era_commons_id, dar.admin_dar_notes,
         dar.approving_so_id, dar.approving_so_timestamp, dar.requires_so_approval,
-        dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id,
         dd.dataset_id, collection.dar_code
       FROM data_access_request dar
       LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
@@ -218,8 +214,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
                 dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
                 data,
                 dd.dataset_id, collection.dar_code, dar.era_commons_id, dar.admin_dar_notes,
-                dar.approving_so_id, dar.approving_so_timestamp, dar.requires_so_approval,
-                dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
+                dar.approving_so_id, dar.approving_so_timestamp, dar.requires_so_approval
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
@@ -245,7 +240,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
               dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
               dar.data, collection.dar_code,
-              dar.era_commons_id, dar.admin_dar_notes, dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id,
+              dar.era_commons_id, dar.admin_dar_notes,
               dar.approving_so_id, dar.approving_so_timestamp, dar.requires_so_approval
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
@@ -267,8 +262,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
               dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
               dar.data, dar.requires_so_approval,
-              collection.dar_code, dar.era_commons_id, dar.admin_dar_notes, dar.closeout_so_approval_timestamp,
-              dar.closeout_approving_so_id, dar.approving_so_id, dar.approving_so_timestamp
+              collection.dar_code, dar.era_commons_id, dar.admin_dar_notes,
+              dar.approving_so_id, dar.approving_so_timestamp
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
@@ -291,8 +286,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
                 dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
                 dar.data, dar.requires_so_approval,
-                collection.dar_code, dar.era_commons_id, dar.admin_dar_notes, dar.closeout_so_approval_timestamp,
-                dar.closeout_approving_so_id, dar.approving_so_id, dar.approving_so_timestamp
+                collection.dar_code, dar.era_commons_id, dar.admin_dar_notes,
+                dar.approving_so_id, dar.approving_so_timestamp
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
@@ -312,7 +307,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
           SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
             dar.data, collection.dar_code,
-            dar.era_commons_id, dar.admin_dar_notes, dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id,
+            dar.era_commons_id, dar.admin_dar_notes,
             dar.approving_so_id, dar.approving_so_timestamp, dar.requires_so_approval
           FROM data_access_request dar
           LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
@@ -484,15 +479,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   void archiveByReferenceIds(
       @BindList(value = "referenceIds", onEmpty = EmptyHandling.NULL_STRING)
           List<String> referenceIds);
-
-  @SqlUpdate(
-      """
-        UPDATE data_access_request
-          SET closeout_approving_so_id = :id, closeout_so_approval_timestamp = now()
-        WHERE reference_id = :referenceId
-    """)
-  void updateDarCloseoutSO(
-      @Bind("id") Integer signingOfficialUserId, @Bind("referenceId") String referenceId);
 
   @SqlUpdate(
       """

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
@@ -57,14 +57,12 @@ public class DarCollectionSummaryReducer
         hasOptionalColumn(rowView, "latest_dar_parent_id", Integer.class)
             .ifPresent(
                 darParentId -> summary.addParentChildRelationship(darParentId, darReferenceId));
-        hasOptionalColumn(rowView, "latest_dar_closeout_approving_so_id", Integer.class)
-            .ifPresent(summary::setCloseoutSigningOfficialId);
-        hasOptionalColumn(rowView, "latest_dar_closeout_so_approval_timestamp", Timestamp.class)
-            .ifPresent(summary::setCloseoutSigningOfficialApprovalDate);
         hasOptionalColumn(rowView, "latest_dar_requires_so_approval", Boolean.class)
             .ifPresent(summary::setRequiresSOApproval);
         hasOptionalColumn(rowView, "latest_dar_so_approver_id", Integer.class)
-            .ifPresent(summary::setSOApprover);
+            .ifPresent(summary::setSoApproverId);
+        hasOptionalColumn(rowView, "latest_dar_so_approver_timestamp", Timestamp.class)
+            .ifPresent(summary::setSoApproverTimestamp);
         darStatus = rowView.getColumn("dar_status", String.class);
         if (Objects.nonNull(darStatus)) {
           summary.addStatus(darStatus, darReferenceId);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -47,13 +47,9 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
     if (hasColumn(resultSet, "admin_dar_notes")) {
       dar.setAdminDarNotes(resultSet.getString("admin_dar_notes"));
     }
-    dar.setCloseoutSigningOfficialApprovedDate(
-        resultSet.getTimestamp("closeout_so_approval_timestamp"));
-    if (hasNonZeroColumn(resultSet, "closeout_approving_so_id")) {
-      dar.setCloseoutSigningOfficialApprovedUserId(resultSet.getInt("closeout_approving_so_id"));
+    if (hasColumn(resultSet, "approving_so_timestamp")) {
+      dar.setApprovingSigningOfficialApprovedDate(resultSet.getTimestamp("approving_so_timestamp"));
     }
-
-    dar.setApprovingSigningOfficialApprovedDate(resultSet.getTimestamp("approving_so_timestamp"));
     if (hasNonZeroColumn(resultSet, "approving_so_id")) {
       dar.setApprovingSigningOfficialUserId(resultSet.getInt("approving_so_id"));
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -21,9 +21,10 @@ public class DarCollection {
           + "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, "
           + "dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date, "
           + "dar.update_date AS dar_update_date, dar.data AS data, "
-          + "dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date, "
-          + "dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id, "
-          + "dar.data ->> 'projectTitle' as projectTitle ";
+          + "dar.data ->> 'projectTitle' as projectTitle, "
+          + "dar.requires_so_approval AS dar_requires_so_approval, "
+          + "dar.approving_so_timestamp AS dar_approving_signing_official_approved_date, "
+          + "dar.approving_so_id AS dar_approving_signing_official_user_id ";
 
   @JsonProperty private Integer darCollectionId;
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
@@ -31,14 +31,13 @@ public class DarCollectionSummary {
   @Expose private final Map<Integer, Set<String>> parentToReferenceIds;
   @Expose private boolean progressReport;
   @Expose private String latestReferenceId;
-  @Expose private Integer closeoutSigningOfficialId;
-  @Expose private Timestamp closeoutSigningOfficialApprovalDate;
   @Expose private List<String> dacNames;
   @Expose private Integer researcherId;
   @Expose private Integer institutionId;
   @Expose private Set<Integer> datasetIds;
   @Expose private boolean requiresSOApproval;
   @Expose private Integer soApproverId;
+  @Expose private Timestamp soApproverTimestamp;
   private String signingOfficialEmail;
 
   // Normally unused by the UI, but used in data population. Can be included in the JSON response
@@ -148,23 +147,6 @@ public class DarCollectionSummary {
     updateProgressReportStatus();
   }
 
-  public void setCloseoutSigningOfficialId(Integer darCloseoutSigningOfficialApprovalId) {
-    this.closeoutSigningOfficialId = darCloseoutSigningOfficialApprovalId;
-  }
-
-  public Timestamp getCloseoutSigningOfficialApprovalDate() {
-    return closeoutSigningOfficialApprovalDate;
-  }
-
-  public void setCloseoutSigningOfficialApprovalDate(
-      Timestamp darCloseoutSigningOfficialApprovalDate) {
-    this.closeoutSigningOfficialApprovalDate = darCloseoutSigningOfficialApprovalDate;
-  }
-
-  public Integer getCloseoutSigningOfficialApprovalId() {
-    return closeoutSigningOfficialId;
-  }
-
   public boolean isExpired() {
     return expired;
   }
@@ -217,12 +199,20 @@ public class DarCollectionSummary {
     return this.requiresSOApproval;
   }
 
-  public void setSOApprover(Integer soUserId) {
+  public void setSoApproverId(Integer soUserId) {
     this.soApproverId = soUserId;
   }
 
-  public Integer getSOApprover() {
+  public Integer getSoApproverId() {
     return this.soApproverId;
+  }
+
+  public void setSoApproverTimestamp(Timestamp soApproverTimestamp) {
+    this.soApproverTimestamp = soApproverTimestamp;
+  }
+
+  public Timestamp getSoApproverTimestamp() {
+    return this.soApproverTimestamp;
   }
 
   public void setDatasetIds(Set<Integer> datasetIds) {

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -65,10 +65,6 @@ public class DataAccessRequest {
   @JsonProperty public Integer approvingSigningOfficialUserId;
   @JsonProperty public Timestamp approvingSigningOfficialApprovedDate;
 
-  @JsonProperty public Timestamp closeoutSigningOfficialApprovedDate;
-
-  @JsonProperty public Integer closeoutSigningOfficialApprovedUserId;
-
   @JsonProperty public boolean requiresSOApproval;
 
   public DataAccessRequest() {
@@ -254,24 +250,6 @@ public class DataAccessRequest {
 
   public void setAdminDarNotes(String adminDarNotes) {
     this.adminDarNotes = adminDarNotes;
-  }
-
-  public Integer getCloseoutSigningOfficialApprovedUserId() {
-    return closeoutSigningOfficialApprovedUserId;
-  }
-
-  public void setCloseoutSigningOfficialApprovedUserId(
-      Integer closeoutSigningOfficialApprovedUserId) {
-    this.closeoutSigningOfficialApprovedUserId = closeoutSigningOfficialApprovedUserId;
-  }
-
-  public Timestamp getCloseoutSigningOfficialApprovedDate() {
-    return closeoutSigningOfficialApprovedDate;
-  }
-
-  public void setCloseoutSigningOfficialApprovedDate(
-      Timestamp closeoutSigningOfficialApprovedDate) {
-    this.closeoutSigningOfficialApprovedDate = closeoutSigningOfficialApprovedDate;
   }
 
   public Integer getApprovingSigningOfficialUserId() {
@@ -494,13 +472,6 @@ public class DataAccessRequest {
     if (dar.getAdminDarNotes() != null) {
       copy.put("adminDarNotes", dar.getAdminDarNotes());
     }
-    if (dar.getCloseoutSigningOfficialApprovedUserId() != null) {
-      copy.put(
-          "closeoutSigningOfficialApprovedUserId", dar.getCloseoutSigningOfficialApprovedUserId());
-    }
-    if (dar.getCloseoutSigningOfficialApprovedDate() != null) {
-      copy.put("closeoutSigningOfficialApprovedDate", dar.getCloseoutSigningOfficialApprovedDate());
-    }
     if (dar.getApprovingSigningOfficialUserId() != null) {
       copy.put("approvingSigningOfficialUserId", dar.getApprovingSigningOfficialUserId());
     }
@@ -525,11 +496,6 @@ public class DataAccessRequest {
         && this.getData() != null
         && this.getData().getCloseoutSupplement() != null
         && !this.getData().getCloseoutSupplement().reasons().isEmpty();
-  }
-
-  public boolean getHasSOCloseoutApproval() {
-    return this.getCloseoutSigningOfficialApprovedDate() != null
-        && this.getCloseoutSigningOfficialApprovedUserId() != null;
   }
 
   public boolean getHasDMI() {

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -316,13 +316,13 @@ public class DarCollectionService implements ConsentLogger {
     if (summary.getCloseoutSupplement() != null) {
       summary.getActions().clear();
       // If the SO has approved the closeout supplement, allow review of the progress report.
-      if (summary.getCloseoutSigningOfficialApprovalDate() != null) {
+      if (summary.getSoApproverId() != null) {
         summary.addAction(DarCollectionActions.REVIEW_PROGRESS_REPORT);
       }
       return;
     }
 
-    boolean canOpen = !summary.requiresSOApproval() || summary.getSOApprover() != null;
+    boolean canOpen = !summary.requiresSOApproval() || summary.getSoApproverId() != null;
     boolean hasOpenElection = Objects.nonNull(openCount);
     boolean hasReopenableElection =
         summary.getElections().values().stream()
@@ -372,12 +372,12 @@ public class DarCollectionService implements ConsentLogger {
   private void updateSummaryActionsForSO(User user, DarCollectionSummary summary) {
     // If the SO has not yet approved the closeout supplement, allow review of the progress report.
     if (summary.getCloseoutSupplement() != null
-        && summary.getCloseoutSigningOfficialApprovalDate() == null
+        && summary.getSoApproverId() == null
         && user.getUserId().equals(summary.getCloseoutSupplement().signingOfficialId())) {
       summary.addAction(DarCollectionActions.REVIEW_PROGRESS_REPORT);
     }
     if (summary.requiresSOApproval()
-        && summary.getSOApprover() == null
+        && summary.getSoApproverId() == null
         && user.getEmail().equalsIgnoreCase(summary.getSigningOfficialEmail())) {
       summary.addAction(DarCollectionActions.APPROVE);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -375,7 +375,7 @@ public class DataAccessRequestService implements ConsentLogger {
   public void approveDataAccessRequestCloseout(User signingOfficial, String referenceId) {
     DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
     validateCloseoutApproval(signingOfficial, dar);
-    dataAccessRequestDAO.updateDarCloseoutSO(signingOfficial.getUserId(), referenceId);
+    dataAccessRequestDAO.updateDarApprovalSO(signingOfficial.getUserId(), referenceId);
     Set<User> chairs = new HashSet<>();
     Set<Dac> dacs = dacService.findByDatasetId(dar.getDatasetIds());
     dacs.forEach(dac -> chairs.addAll(dac.getChairpersons()));
@@ -403,7 +403,7 @@ public class DataAccessRequestService implements ConsentLogger {
           "Signing officials can only approve closeout progress reports.");
     }
 
-    if (dataAccessRequest.getHasSOCloseoutApproval()) {
+    if (dataAccessRequest.getApprovingSigningOfficialUserId() != null) {
       throw new BadRequestException(
           "This progress report closeout has already been approved by a signing official.");
     }

--- a/src/main/resources/assets/schemas/DarCollectionSummary.yaml
+++ b/src/main/resources/assets/schemas/DarCollectionSummary.yaml
@@ -46,12 +46,12 @@ properties:
   progressReport:
     type: boolean
     description: Indicator true when the collection contains a progress report.
-  closeoutSigningOfficialApprovedDate:
+  soApproverId:
+    type: integer
+    description: The user ID of the Signing Official that approved this collection (applies to both regular and closeout DARs). Null if not yet approved.
+  soApproverTimestamp:
     type: number
-    description: When the Signing Official approved the closeout, in milliseconds since the epoch.
-  closeoutSigningOfficialApprovedUserId:
-    type: number
-    description: The user ID of the Signing Official that approved the closeout.
+    description: When the Signing Official approved this collection, in milliseconds since the epoch (applies to both regular and closeout DARs). Null if not yet approved.
   dacNames:
     type: array
     description: List of DAC names associated with this collection.

--- a/src/main/resources/assets/schemas/DataAccessRequest.yaml
+++ b/src/main/resources/assets/schemas/DataAccessRequest.yaml
@@ -16,21 +16,15 @@ properties:
   updateDate:
     type: number
     description: Update Date
-  closeoutSigningOfficialApprovedDate:
-    type: number
-    description: When the Signing Official approved the closeout, in milliseconds since the epoch.
-  closeoutSigningOfficialApprovedUserId:
-    type: number
-    description: The user ID of the Signing Official that approved the closeout.
   requiresSOApproval:
     type: boolean
     description: True if this Data Access Request requires Signing Official Approval
   approvingSigningOfficialUserId:
     type: number
-    description: The user ID of the Signing Official that approved this request.
+    description: The user ID of the Signing Official that approved this request (applies to both regular and closeout DARs).
   approvingSigningOfficialApprovedDate:
     type: number
-    description: When the Signing Official approved this data access request, in milliseconds since the epoch.
+    description: When the Signing Official approved this data access request, in milliseconds since the epoch (applies to both regular and closeout DARs).
   draft:
     type: boolean
     description: Draft status of this DAR

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -252,4 +252,5 @@
   <include file="changesets/changelog-consent-2026-06-11-drop-datarequest-researchpurpose.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-06-16-bff-01-user-sessions.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-06-16-bff-02-user-session-audit.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-06-18-consolidate-so-approval-fields.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-06-18-consolidate-so-approval-fields.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-06-18-consolidate-so-approval-fields.xml
@@ -1,0 +1,24 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2026-06-18-consolidate-so-approval-fields" author="otchet">
+    <!-- Enforce the invariant: a DAR is either a progress report or a regular submission, never both.
+         If both approval columns are set on any row, halt rather than silently discard data. -->
+    <preConditions onFail="HALT">
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(*) FROM data_access_request
+        WHERE closeout_approving_so_id IS NOT NULL AND approving_so_id IS NOT NULL
+      </sqlCheck>
+    </preConditions>
+    <!-- Migrate existing closeout SO approvals into the shared approval columns -->
+    <sql>
+      UPDATE data_access_request
+      SET approving_so_id        = closeout_approving_so_id,
+          approving_so_timestamp = closeout_so_approval_timestamp
+      WHERE closeout_approving_so_id IS NOT NULL
+    </sql>
+    <dropForeignKeyConstraint baseTableName="data_access_request" constraintName="fk_so_user_id"/>
+    <dropColumn tableName="data_access_request" columnName="closeout_approving_so_id"/>
+    <dropColumn tableName="data_access_request" columnName="closeout_so_approval_timestamp"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -167,47 +167,46 @@ class DarCollectionDAOTest extends DAOTestHelper {
     DataAccessRequest testDar1 = (DataAccessRequest) collectionWithDataset.get(4);
     Dataset dataset = (Dataset) collectionWithDataset.get(2);
     DataAccessRequest testDar2 = createDAR(user, dataset, testDar1.getCollectionId());
-    dataAccessRequestDAO.updateDarCloseoutSO(user.getUserId(), testDar2.getReferenceId());
+    dataAccessRequestDAO.updateDarApprovalSO(user.getUserId(), testDar2.getReferenceId());
 
     DataAccessRequest testDar2Stored =
         dataAccessRequestDAO.findByReferenceId(testDar2.getReferenceId());
-    assertNotNull(testDar2Stored.getCloseoutSigningOfficialApprovedUserId());
-    assertNotNull(testDar2Stored.getCloseoutSigningOfficialApprovedDate());
+    assertNotNull(testDar2Stored.getApprovingSigningOfficialUserId());
+    assertNotNull(testDar2Stored.getApprovingSigningOfficialApprovedDate());
 
     DarCollection darCollection =
         darCollectionDAO.findDARCollectionByCollectionId(testDar2.getCollectionId());
 
-    assertNotNull(darCollection.getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
+    assertNotNull(darCollection.getMostRecentDar().getApprovingSigningOfficialApprovedDate());
     assertEquals(
-        user.getUserId(),
-        darCollection.getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
+        user.getUserId(), darCollection.getMostRecentDar().getApprovingSigningOfficialUserId());
 
     DarCollection darCollectionByReferenceId =
         darCollectionDAO.findDARCollectionByReferenceId(testDar2.getReferenceId());
     assertNotNull(
-        darCollectionByReferenceId.getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
+        darCollectionByReferenceId.getMostRecentDar().getApprovingSigningOfficialApprovedDate());
     assertEquals(
         user.getUserId(),
-        darCollectionByReferenceId.getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
+        darCollectionByReferenceId.getMostRecentDar().getApprovingSigningOfficialUserId());
 
     DarCollection darCollectionWithElectionsById =
         darCollectionDAO.findCollectionWithAllElectionsByCollectionId(testDar2.getCollectionId());
     assertNotNull(
-        darCollectionWithElectionsById.getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
-    assertEquals(
-        user.getUserId(),
         darCollectionWithElectionsById
             .getMostRecentDar()
-            .getCloseoutSigningOfficialApprovedUserId());
+            .getApprovingSigningOfficialApprovedDate());
+    assertEquals(
+        user.getUserId(),
+        darCollectionWithElectionsById.getMostRecentDar().getApprovingSigningOfficialUserId());
 
     List<DarCollection> darCollectionList =
         darCollectionDAO.findDARCollectionByCollectionIds(List.of(testDar2.getCollectionId()));
     assertEquals(1, darCollectionList.size());
     assertNotNull(
-        darCollectionList.getFirst().getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
+        darCollectionList.getFirst().getMostRecentDar().getApprovingSigningOfficialApprovedDate());
     assertEquals(
         user.getUserId(),
-        darCollectionList.getFirst().getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
+        darCollectionList.getFirst().getMostRecentDar().getApprovingSigningOfficialUserId());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -335,8 +335,8 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     assertEquals(collectionOneId, summaries.get(0).getDarCollectionId());
-    assertNull(summaries.get(0).getCloseoutSigningOfficialApprovalDate());
-    assertNull(summaries.get(0).getCloseoutSigningOfficialApprovalId());
+    assertNull(summaries.get(0).getSoApproverId());
+    assertNull(summaries.get(0).getSoApproverTimestamp());
   }
 
   @Test
@@ -357,9 +357,9 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     Integer collectionOneId = createDarCollection(userOneId);
     Integer collectionTwoId = createDarCollection(userTwoId);
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
-    dataAccessRequestDAO.updateDarCloseoutSO(userOneId, darOne.getReferenceId());
+    dataAccessRequestDAO.updateDarApprovalSO(userOneId, darOne.getReferenceId());
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
-    dataAccessRequestDAO.updateDarCloseoutSO(userOneId, darTwo.getReferenceId());
+    dataAccessRequestDAO.updateDarApprovalSO(userOneId, darTwo.getReferenceId());
 
     dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(
@@ -391,8 +391,8 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
           Integer electionId = collectionOneElection.getElectionId();
           s.getElections().forEach((key, value) -> assertEquals(electionId, key));
           assertEquals(1, s.getDatasetCount());
-          assertEquals(userOneId, s.getCloseoutSigningOfficialApprovalId());
-          assertNotNull(s.getCloseoutSigningOfficialApprovalDate());
+          assertEquals(userOneId, s.getSoApproverId());
+          assertNotNull(s.getSoApproverTimestamp());
         });
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -1310,13 +1310,13 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         createDataAccessRequest(collection, user.getUserId(), Date.from(Instant.now()));
     dataAccessRequestDAO.insertDARDatasetRelation(
         darToStore.getReferenceId(), dataset.getDatasetId());
-    dataAccessRequestDAO.updateDarCloseoutSO(
+    dataAccessRequestDAO.updateDarApprovalSO(
         signingOfficial.getUserId(), darToStore.getReferenceId());
 
     DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(darToStore.getReferenceId());
 
-    assertEquals(dar.getCloseoutSigningOfficialApprovedUserId(), signingOfficial.getUserId());
-    assertNotNull(dar.getCloseoutSigningOfficialApprovedDate());
+    assertEquals(dar.getApprovingSigningOfficialUserId(), signingOfficial.getUserId());
+    assertNotNull(dar.getApprovingSigningOfficialApprovedDate());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestTest.java
@@ -106,20 +106,6 @@ class DataAccessRequestTest {
   }
 
   @Test
-  void testGetHasCloseoutApproval_False() {
-    DataAccessRequest dar = new DataAccessRequest();
-    assertFalse(dar.getHasSOCloseoutApproval());
-  }
-
-  @Test
-  void testGetHasCloseoutApproval_True() {
-    DataAccessRequest dar = new DataAccessRequest();
-    dar.setCloseoutSigningOfficialApprovedUserId(1);
-    dar.setCloseoutSigningOfficialApprovedDate(Timestamp.from(Instant.now()));
-    assertTrue(dar.getHasSOCloseoutApproval());
-  }
-
-  @Test
   void testGetHasDMI_NoData() {
     DataAccessRequest dar = new DataAccessRequest();
     assertFalse(dar.getHasDMI());
@@ -229,8 +215,6 @@ class DataAccessRequestTest {
     dar.setCreateDate(now);
     dar.setApprovingSigningOfficialUserId(1);
     dar.setApprovingSigningOfficialApprovedDate(now);
-    dar.setCloseoutSigningOfficialApprovedDate(now);
-    dar.setCloseoutSigningOfficialApprovedUserId(1);
     dar.setRequiresSOApproval(true);
     dar.setAdminDarNotes("admin notes");
     Map<String, Object> simplifiedDar = assertDoesNotThrow(dar::convertToSimplifiedDar);

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -722,7 +722,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
     dar.setUserId(user.getUserId());
-    dar.setCloseoutSigningOfficialApprovedUserId(signingOfficial.getUserId());
     DataAccessRequestData darData = new DataAccessRequestData();
     darData.setSigningOfficialEmail(signingOfficial.getEmail());
     darData.setDmi(new DataManagementIncident(List.of("one"), "my incident"));
@@ -737,6 +736,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     service.approveDarCollection(signingOfficial, collection, request);
     verify(dacAutomationRuleService, never())
         .triggerDACRuleSettings(any(), anyList(), anyString(), any());
+    verify(dataAccessRequestDAO)
+        .updateDarApprovalSO(signingOfficial.getUserId(), dar.getReferenceId());
   }
 
   @Test
@@ -752,7 +753,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     dar.setParentId(-1);
     dar.setReferenceId(UUID.randomUUID().toString());
     dar.setUserId(user.getUserId());
-    dar.setCloseoutSigningOfficialApprovedUserId(signingOfficial.getUserId());
     DataAccessRequestData darData = new DataAccessRequestData();
     darData.setSigningOfficialEmail(signingOfficial.getEmail());
     darData.setCloseoutSupplement(
@@ -768,6 +768,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     service.approveDarCollection(signingOfficial, collection, request);
     verify(dacAutomationRuleService, never())
         .triggerDACRuleSettings(any(), anyList(), anyString(), any());
+    verify(dataAccessRequestDAO)
+        .updateDarApprovalSO(signingOfficial.getUserId(), dar.getReferenceId());
   }
 
   @Test
@@ -1093,7 +1095,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     summary.addDatasetId(datasetOne.getDatasetId());
     summary.addDatasetId(datasetTwo.getDatasetId());
     summary.setRequiresSOApproval(true);
-    summary.setSOApprover(1);
+    summary.setSoApproverId(1);
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(any()))
         .thenReturn(List.of(summary));
 
@@ -1320,7 +1322,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         new CloseoutSupplement(List.of("Closeout"), "Closeout", 1);
     summary.setCloseoutSupplement(closeoutSupplement);
 
-    summary.setCloseoutSigningOfficialApprovalDate(null);
+    summary.setSoApproverId(null);
 
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(user.getInstitutionId()))
         .thenReturn(List.of(summary));
@@ -1353,7 +1355,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         new CloseoutSupplement(List.of("Closeout"), "Closeout", 1);
     summary.setCloseoutSupplement(closeoutSupplement);
 
-    summary.setCloseoutSigningOfficialApprovalDate(null);
+    summary.setSoApproverId(null);
 
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(user.getInstitutionId()))
         .thenReturn(List.of(summary));
@@ -1384,7 +1386,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         new CloseoutSupplement(List.of("Closeout"), "Closeout", 1);
     summary.setCloseoutSupplement(closeoutSupplement);
 
-    summary.setCloseoutSigningOfficialApprovalDate(new Timestamp(System.currentTimeMillis()));
+    summary.setSoApproverId(user.getUserId());
 
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(user.getInstitutionId()))
         .thenReturn(List.of(summary));
@@ -1410,7 +1412,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         new CloseoutSupplement(List.of("Closeout"), "Closeout", 1);
     summary.setCloseoutSupplement(closeoutSupplement);
 
-    summary.setCloseoutSigningOfficialApprovalDate(new Timestamp(System.currentTimeMillis()));
+    summary.setSoApproverId(user.getUserId());
 
     when(darCollectionSummaryDAO.getDarCollectionSummariesForDACRole(
             user.getUserId(), UserRoles.CHAIRPERSON.getRoleId()))
@@ -1837,7 +1839,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DarCollectionSummary summary = new DarCollectionSummary();
     summary.setLatestReferenceId(UUID.randomUUID().toString());
     summary.setRequiresSOApproval(true);
-    summary.setSOApprover(1);
+    summary.setSoApproverId(1);
     summary.addDatasetId(1);
     when(darCollectionSummaryDAO.getDarCollectionSummariesForDACRole(
             user.getUserId(), UserRoles.CHAIRPERSON.getRoleId()))

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -1990,8 +1990,8 @@ institution or library cards issued: Internal Collaborator member:  \
     DataAccessRequest dar = new DataAccessRequest();
     dar.setSubmissionDate(Timestamp.from(Instant.now()));
     dar.setParentId(1);
-    dar.setCloseoutSigningOfficialApprovedDate(Timestamp.from(Instant.now()));
-    dar.setCloseoutSigningOfficialApprovedUserId(1);
+    dar.setApprovingSigningOfficialApprovedDate(Timestamp.from(Instant.now()));
+    dar.setApprovingSigningOfficialUserId(1);
     DataAccessRequestData data = new DataAccessRequestData();
     data.setCloseoutSupplement(new CloseoutSupplement(List.of(""), "", 1));
     dar.setData(data);


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2840](https://broadworkbench.atlassian.net/browse/DT-2840)

### Summary

### Consolidate SO approval fields on data_access_request
#### Background
Two separate column pairs on data_access_request recorded the same kind of information — the Signing Official who approved a DAR and when — for two different DAR types:

closeout_approving_so_id / closeout_so_approval_timestamp — set when an SO approves a closeout progress report
approving_so_id / approving_so_timestamp — set when an SO approves a regular DAR submission
Because a given DAR is always either a progress report or a regular submission (never both), these column pairs were never simultaneously populated on the same row. This change removes the redundancy by migrating existing closeout approval data into the shared columns and dropping the closeout-specific columns.

### Changes
#### Database

New Liquibase changeset (changelog-consent-2026-06-18-consolidate-so-approval-fields.xml) that:
Halts with a precondition check if any row unexpectedly has both column pairs set (enforces the architectural invariant rather than silently discarding data)
Migrates existing closeout SO approvals into approving_so_id / approving_so_timestamp
Drops the FK constraint and the two closeout columns

#### DAO layer

DataAccessRequestDAO: removed updateDarCloseoutSO; callers now use updateDarApprovalSO for both approval paths. Removed closeout_approving_so_id and closeout_so_approval_timestamp from all SELECT queries.
DarCollectionDAO / DarCollection.DAR_FILTER_QUERY_COLUMNS: removed the two closeout column aliases; added approving_so_id and approving_so_timestamp to the shared DAR_FILTER_QUERY_COLUMNS constant so all four collection query methods return SO approval state consistently.
DarCollectionSummaryDAO: added approving_so_timestamp projection to all six summary queries (as latest_dar_so_approver_timestamp), alongside the existing approving_so_id projection.
DataAccessRequestMapper: added hasColumn guard for approving_so_timestamp to match the guard pattern used for approving_so_id.
DarCollectionSummaryReducer: maps latest_dar_so_approver_timestamp → soApproverTimestamp on DarCollectionSummary.

#### Model layer

DataAccessRequest: removed closeoutSigningOfficialApprovedDate, closeoutSigningOfficialApprovedUserId, and the derived getHasSOCloseoutApproval() helper (callers now check getApprovingSigningOfficialUserId() != null directly).
DarCollectionSummary: removed closeoutSigningOfficialId / closeoutSigningOfficialApprovalDate; added soApproverTimestamp field with getter/setter. Renamed getSOApprover() / setSOApprover() to getSoApproverId() / setSoApproverId() to follow JavaBeans convention.

#### Service layer

DataAccessRequestService.approveDataAccessRequestCloseout: replaced updateDarCloseoutSO with updateDarApprovalSO.
DataAccessRequestService.validateCloseoutApproval: replaced getHasSOCloseoutApproval() with a direct null check on getApprovingSigningOfficialUserId().
DarCollectionService: updated closeout action gates (REVIEW_PROGRESS_REPORT, APPROVE) to use getSoApproverId().
API documentation

DataAccessRequest.yaml: removed closeoutSigningOfficialApprovedDate and closeoutSigningOfficialApprovedUserId; updated descriptions of approvingSigningOfficialUserId and approvingSigningOfficialApprovedDate to note they apply to both regular and closeout DARs.
DarCollectionSummary.yaml: added soApproverTimestamp.

#### Note
A related [PR is open for DUOS-UI](https://github.com/DataBiosphere/duos-ui/pull/3611).  This change must go with that change.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
