### PR TITLE
[DT-3601] Migrate to @Singleton for provider methods.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -215,7 +215,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(feature);
     env.jersey().register(binder);
 
-    env.jersey().register(RequestHeaderCacheFilter.class);
+    env.jersey().register(injector.getInstance(RequestHeaderCacheFilter.class));
     env.jersey().register(RolesAllowedDynamicFeature.class);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -215,6 +215,10 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(feature);
     env.jersey().register(binder);
 
+    // Filters and providers that have @Inject dependencies must be registered via
+    // injector.getInstance() so Guice performs field/constructor injection. Class-literal
+    // registration (e.g. RolesAllowedDynamicFeature.class below) is only safe for classes
+    // with a public no-arg constructor and no @Inject dependencies.
     env.jersey().register(injector.getInstance(RequestHeaderCacheFilter.class));
     env.jersey().register(RolesAllowedDynamicFeature.class);
   }

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -81,7 +81,6 @@ import org.broadinstitute.consent.http.service.dao.UserServiceDAO;
 import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.broadinstitute.consent.http.service.feature.InstitutionAndLibraryCardEnforcement;
 import org.broadinstitute.consent.http.service.ontology.ElasticSearchSupport;
-import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.broadinstitute.consent.http.util.ConsentLogger;
@@ -116,7 +115,6 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   private final LibraryCardDAO libraryCardDAO;
   private final FileStorageObjectDAO fileStorageObjectDAO;
   private final DraftDAO draftDAO;
-  private final OntologyDAO ontologyDAO;
   private final ExecutorService executorService;
 
   // Lazily-memoized singletons. @Singleton on a @Provides method only covers resolution
@@ -209,7 +207,6 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
     this.libraryCardDAO = this.jdbi.onDemand((LibraryCardDAO.class));
     this.fileStorageObjectDAO = this.jdbi.onDemand((FileStorageObjectDAO.class));
     this.draftDAO = this.jdbi.onDemand(DraftDAO.class);
-    this.ontologyDAO = this.jdbi.onDemand(OntologyDAO.class);
 
     // All async work in this application is blocking I/O (Sam calls, Elasticsearch indexing,
     // batch DB writes), so a single shared virtual-thread executor replaces the per-class
@@ -250,19 +247,19 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  ExecutorService providesExecutorService() {
+  private ExecutorService providesExecutorService() {
     return executorService;
   }
 
   @Provides
   @Singleton
-  Client providesClient() {
+  private Client providesClient() {
     return client;
   }
 
   @Provides
   @Singleton
-  synchronized HttpClientUtil providesHttpClientUtil() {
+  private synchronized HttpClientUtil providesHttpClientUtil() {
     if (httpClientUtil == null) {
       httpClientUtil = new HttpClientUtil(config.getServicesConfiguration());
     }
@@ -271,13 +268,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  Jdbi providesJdbi() {
+  private Jdbi providesJdbi() {
     return jdbi;
   }
 
   @Provides
   @Singleton
-  synchronized ElasticSearchConfiguration providesElasticSearchConfiguration() {
+  private synchronized ElasticSearchConfiguration providesElasticSearchConfiguration() {
     if (elasticSearchConfiguration == null) {
       elasticSearchConfiguration = config.getElasticSearchConfiguration();
     }
@@ -286,7 +283,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized MailConfiguration providesMailConfiguration() {
+  private synchronized MailConfiguration providesMailConfiguration() {
     if (mailConfiguration == null) {
       mailConfiguration = config.getMailConfiguration();
     }
@@ -295,7 +292,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized ServicesConfiguration providesServicesConfiguration() {
+  private synchronized ServicesConfiguration providesServicesConfiguration() {
     if (servicesConfiguration == null) {
       servicesConfiguration = config.getServicesConfiguration();
     }
@@ -304,13 +301,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  HealthCheckRegistry providesHealthCheckRegistry() {
+  private HealthCheckRegistry providesHealthCheckRegistry() {
     return environment.healthChecks();
   }
 
   @Provides
   @Singleton
-  synchronized UseRestrictionConverter providesUseRestrictionConverter() {
+  private synchronized UseRestrictionConverter providesUseRestrictionConverter() {
     if (useRestrictionConverter == null) {
       useRestrictionConverter = new UseRestrictionConverter();
     }
@@ -319,7 +316,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized OntologyService providesOntologyService() {
+  private synchronized OntologyService providesOntologyService() {
     if (ontologyService == null) {
       ontologyService =
           new OntologyService(
@@ -333,7 +330,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized OntologyIndexService providesOntologyIndexService() {
+  private synchronized OntologyIndexService providesOntologyIndexService() {
     if (ontologyIndexService == null) {
       ontologyIndexService =
           new OntologyIndexService(providesGCSService(), config.getCloudStoreConfiguration());
@@ -343,7 +340,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized AuthorizationHelper providesAuthorizationHelper() {
+  private synchronized AuthorizationHelper providesAuthorizationHelper() {
     if (authorizationHelper == null) {
       authorizationHelper =
           new AuthorizationHelper(
@@ -354,7 +351,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized OAuthAuthenticator providesOAuthAuthenticator() {
+  private synchronized OAuthAuthenticator providesOAuthAuthenticator() {
     if (oauthAuthenticator == null) {
       oauthAuthenticator = new OAuthAuthenticator(providesAuthorizationHelper());
     }
@@ -363,7 +360,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DuosUserAuthenticator providesDuosUserOAuthAuthenticator() {
+  private synchronized DuosUserAuthenticator providesDuosUserOAuthAuthenticator() {
     if (duosUserAuthenticator == null) {
       duosUserAuthenticator = new DuosUserAuthenticator(providesAuthorizationHelper());
     }
@@ -372,7 +369,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DarCollectionService providesDarCollectionService() {
+  private synchronized DarCollectionService providesDarCollectionService() {
     if (darCollectionService == null) {
       darCollectionService =
           new DarCollectionService(
@@ -386,7 +383,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized FileStorageObjectService providesFileStorageObjectService() {
+  private synchronized FileStorageObjectService providesFileStorageObjectService() {
     if (fileStorageObjectService == null) {
       fileStorageObjectService =
           new FileStorageObjectService(
@@ -402,7 +399,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized GCSService providesGCSService() {
+  private synchronized GCSService providesGCSService() {
     if (gcsService == null) {
       gcsService = new GCSService(config.getCloudStoreConfiguration());
     }
@@ -411,7 +408,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized CounterService providesCounterService() {
+  private synchronized CounterService providesCounterService() {
     if (counterService == null) {
       counterService = new CounterService(providesJdbi());
     }
@@ -420,7 +417,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DACAutomationRuleService providesRuleService() {
+  private synchronized DACAutomationRuleService providesRuleService() {
     if (ruleService == null) {
       ruleService =
           new DACAutomationRuleService(
@@ -431,7 +428,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DataAccessRequestService providesDataAccessRequestService() {
+  private synchronized DataAccessRequestService providesDataAccessRequestService() {
     if (dataAccessRequestService == null) {
       dataAccessRequestService =
           new DataAccessRequestService(
@@ -451,7 +448,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DatasetServiceDAO providesDatasetServiceDAO() {
+  private synchronized DatasetServiceDAO providesDatasetServiceDAO() {
     if (datasetServiceDAO == null) {
       datasetServiceDAO = new DatasetServiceDAO(providesJdbi());
     }
@@ -460,7 +457,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DatasetService providesDatasetService() {
+  private synchronized DatasetService providesDatasetService() {
     if (datasetService == null) {
       datasetService =
           new DatasetService(
@@ -475,7 +472,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized ElectionService providesElectionService() {
+  private synchronized ElectionService providesElectionService() {
     if (electionService == null) {
       electionService = new ElectionService(providesJdbi());
     }
@@ -484,7 +481,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized FreeMarkerTemplateHelper providesFreeMarkerTemplateHelper() {
+  private synchronized FreeMarkerTemplateHelper providesFreeMarkerTemplateHelper() {
     if (freeMarkerTemplateHelper == null) {
       freeMarkerTemplateHelper = new FreeMarkerTemplateHelper(config.getFreeMarkerConfiguration());
     }
@@ -493,7 +490,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized EmailService providesEmailService() {
+  private synchronized EmailService providesEmailService() {
     if (emailService == null) {
       emailService =
           new EmailService(
@@ -504,7 +501,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized FeatureFlagService providesFeatureFlagService() {
+  private synchronized FeatureFlagService providesFeatureFlagService() {
     if (featureFlagService == null) {
       featureFlagService = new FeatureFlagService(providesJdbi());
     }
@@ -513,7 +510,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized SendGridAPI providesSendGridAPI() {
+  private synchronized SendGridAPI providesSendGridAPI() {
     if (sendGridAPI == null) {
       sendGridAPI = new SendGridAPI(config.getMailConfiguration(), providesJdbi());
     }
@@ -522,19 +519,19 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  DataAccessRequestDAO providesDataAccessRequestDAO() {
+  private DataAccessRequestDAO providesDataAccessRequestDAO() {
     return dataAccessRequestDAO;
   }
 
   @Provides
   @Singleton
-  DarCollectionDAO providesDARCollectionDAO() {
+  private DarCollectionDAO providesDARCollectionDAO() {
     return darCollectionDAO;
   }
 
   @Provides
   @Singleton
-  synchronized DarCollectionServiceDAO providesDarCollectionServiceDAO() {
+  private synchronized DarCollectionServiceDAO providesDarCollectionServiceDAO() {
     if (darCollectionServiceDAO == null) {
       darCollectionServiceDAO = new DarCollectionServiceDAO(providesJdbi());
     }
@@ -543,7 +540,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DataAccessRequestServiceDAO providesDataAccessRequestServiceDAO() {
+  private synchronized DataAccessRequestServiceDAO providesDataAccessRequestServiceDAO() {
     if (dataAccessRequestServiceDAO == null) {
       dataAccessRequestServiceDAO = new DataAccessRequestServiceDAO(providesJdbi());
     }
@@ -552,25 +549,25 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  ElectionDAO providesElectionDAO() {
+  private ElectionDAO providesElectionDAO() {
     return electionDAO;
   }
 
   @Provides
   @Singleton
-  VoteDAO providesVoteDAO() {
+  private VoteDAO providesVoteDAO() {
     return voteDAO;
   }
 
   @Provides
   @Singleton
-  StudyDAO providesStudyDAO() {
+  private StudyDAO providesStudyDAO() {
     return studyDAO;
   }
 
   @Provides
   @Singleton
-  synchronized VoteServiceDAO providesVoteServiceDAO() {
+  private synchronized VoteServiceDAO providesVoteServiceDAO() {
     if (voteServiceDAO == null) {
       voteServiceDAO = new VoteServiceDAO(providesJdbi());
     }
@@ -579,7 +576,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized VoteService providesVoteService() {
+  private synchronized VoteService providesVoteService() {
     if (voteService == null) {
       voteService =
           new VoteService(
@@ -593,19 +590,19 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  DatasetAuthorizationReaderDAO providesDatasetAuthorizationReaderDAO() {
+  private DatasetAuthorizationReaderDAO providesDatasetAuthorizationReaderDAO() {
     return datasetAuthorizationReaderDAO;
   }
 
   @Provides
   @Singleton
-  DatasetDAO providesDatasetDAO() {
+  private DatasetDAO providesDatasetDAO() {
     return datasetDAO;
   }
 
   @Provides
   @Singleton
-  synchronized DaaServiceDAO providesDaaServiceDAO() {
+  private synchronized DaaServiceDAO providesDaaServiceDAO() {
     if (daaServiceDAO == null) {
       daaServiceDAO = new DaaServiceDAO(providesJdbi());
     }
@@ -614,7 +611,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DacServiceDAO providesDacServiceDAO() {
+  private synchronized DacServiceDAO providesDacServiceDAO() {
     if (dacServiceDAO == null) {
       dacServiceDAO = new DacServiceDAO(providesJdbi());
     }
@@ -623,13 +620,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  DaaDAO providesDaaDAO() {
+  private DaaDAO providesDaaDAO() {
     return daaDAO;
   }
 
   @Provides
   @Singleton
-  synchronized DaaService providesDaaService() {
+  private synchronized DaaService providesDaaService() {
     if (daaService == null) {
       daaService =
           new DaaService(
@@ -645,7 +642,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DacService providesDacService() {
+  private synchronized DacService providesDacService() {
     if (dacService == null) {
       dacService =
           new DacService(
@@ -660,7 +657,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized ElasticSearchService providesElasticSearchService() {
+  private synchronized ElasticSearchService providesElasticSearchService() {
     if (elasticSearchService == null) {
       elasticSearchService =
           new ElasticSearchService(
@@ -675,19 +672,19 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  UserDAO providesUserDAO() {
+  private UserDAO providesUserDAO() {
     return userDAO;
   }
 
   @Provides
   @Singleton
-  UserRoleDAO providesUserRoleDAO() {
+  private UserRoleDAO providesUserRoleDAO() {
     return userRoleDAO;
   }
 
   @Provides
   @Singleton
-  synchronized MatchService providesMatchService() {
+  private synchronized MatchService providesMatchService() {
     if (matchService == null) {
       matchService =
           new MatchService(
@@ -698,7 +695,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized MetricsService providesMetricsService() {
+  private synchronized MetricsService providesMetricsService() {
     if (metricsService == null) {
       metricsService = new MetricsService(providesJdbi());
     }
@@ -707,19 +704,19 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  FileStorageObjectDAO providesFileStorageObjectDAO() {
+  private FileStorageObjectDAO providesFileStorageObjectDAO() {
     return fileStorageObjectDAO;
   }
 
   @Provides
   @Singleton
-  LibraryCardDAO providesLibraryCardDAO() {
+  private LibraryCardDAO providesLibraryCardDAO() {
     return libraryCardDAO;
   }
 
   @Provides
   @Singleton
-  synchronized InstitutionService providesInstitutionService() {
+  private synchronized InstitutionService providesInstitutionService() {
     if (institutionService == null) {
       institutionService =
           new InstitutionService(providesJdbi(), providesInstitutionAndLibraryCardEnforcement());
@@ -729,7 +726,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized LibraryCardService providesLibraryCardService() {
+  private synchronized LibraryCardService providesLibraryCardService() {
     if (libraryCardService == null) {
       libraryCardService =
           new LibraryCardService(
@@ -740,7 +737,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized AcknowledgementService providesAcknowledgementService() {
+  private synchronized AcknowledgementService providesAcknowledgementService() {
     if (acknowledgementService == null) {
       acknowledgementService = new AcknowledgementService(providesJdbi(), providesEmailService());
     }
@@ -749,7 +746,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DatasetRegistrationService providesDatasetRegistrationService() {
+  private synchronized DatasetRegistrationService providesDatasetRegistrationService() {
     if (datasetRegistrationService == null) {
       datasetRegistrationService =
           new DatasetRegistrationService(
@@ -765,7 +762,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized UserServiceDAO providesUserServiceDAO() {
+  private synchronized UserServiceDAO providesUserServiceDAO() {
     if (userServiceDAO == null) {
       userServiceDAO = new UserServiceDAO(providesJdbi());
     }
@@ -774,7 +771,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized UserService providesUserService() {
+  private synchronized UserService providesUserService() {
     if (userService == null) {
       userService =
           new UserService(
@@ -788,7 +785,8 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized InstitutionAndLibraryCardEnforcement providesInstitutionAndLibraryCardEnforcement() {
+  private synchronized InstitutionAndLibraryCardEnforcement
+      providesInstitutionAndLibraryCardEnforcement() {
     if (institutionAndLibraryCardEnforcement == null) {
       institutionAndLibraryCardEnforcement =
           new InstitutionAndLibraryCardEnforcement(
@@ -799,7 +797,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized NihService providesNihService() {
+  private synchronized NihService providesNihService() {
     if (nihService == null) {
       nihService =
           new NihService(
@@ -813,7 +811,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized NihServiceDAO providesNIHServiceDAO() {
+  private synchronized NihServiceDAO providesNIHServiceDAO() {
     if (nihServiceDAO == null) {
       nihServiceDAO = new NihServiceDAO(providesJdbi());
     }
@@ -822,7 +820,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized SamService providesSamService() {
+  private synchronized SamService providesSamService() {
     if (samService == null) {
       samService = new SamService(providesSamDAO());
     }
@@ -831,7 +829,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized SamDAO providesSamDAO() {
+  private synchronized SamDAO providesSamDAO() {
     if (samDAO == null) {
       samDAO =
           new SamDAO(
@@ -844,7 +842,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized OidcConfiguration providesOidcConfiguration() {
+  private synchronized OidcConfiguration providesOidcConfiguration() {
     if (oidcConfiguration == null) {
       oidcConfiguration = config.getOidcConfiguration();
     }
@@ -853,7 +851,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized OidcAuthorityDAO providesOidcAuthorityDAO() {
+  private synchronized OidcAuthorityDAO providesOidcAuthorityDAO() {
     if (oidcAuthorityDAO == null) {
       oidcAuthorityDAO =
           new OidcAuthorityDAO(providesHttpClientUtil(), providesOidcConfiguration());
@@ -863,7 +861,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized OidcService providesOidcService() {
+  private synchronized OidcService providesOidcService() {
     if (oidcService == null) {
       oidcService = new OidcService(providesOidcAuthorityDAO(), providesOidcConfiguration());
     }
@@ -872,7 +870,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized SupportRequestService providesSupportRequestService() {
+  private synchronized SupportRequestService providesSupportRequestService() {
     if (supportRequestService == null) {
       supportRequestService =
           new SupportRequestService(
@@ -883,13 +881,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  DraftDAO providesDraftDAO() {
+  private DraftDAO providesDraftDAO() {
     return draftDAO;
   }
 
   @Provides
   @Singleton
-  synchronized DraftFileStorageServiceDAO providesDraftFileStorageService() {
+  private synchronized DraftFileStorageServiceDAO providesDraftFileStorageService() {
     if (draftFileStorageServiceDAO == null) {
       draftFileStorageServiceDAO =
           new DraftFileStorageServiceDAO(providesJdbi(), providesGCSService());
@@ -899,7 +897,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DraftServiceDAO providesDraftServiceDAO() {
+  private synchronized DraftServiceDAO providesDraftServiceDAO() {
     if (draftServiceDAO == null) {
       draftServiceDAO = new DraftServiceDAO(providesJdbi(), providesDraftFileStorageService());
     }
@@ -908,13 +906,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  OntologyDAO providesOntologyDAO() {
-    return ontologyDAO;
-  }
-
-  @Provides
-  @Singleton
-  synchronized ClaimsCache providesClaimsCache() {
+  private synchronized ClaimsCache providesClaimsCache() {
     if (claimsCache == null) {
       claimsCache = new ClaimsCache();
     }
@@ -923,16 +915,16 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized TranslationUtil providesTranslationUtil() {
+  private synchronized TranslationUtil providesTranslationUtil() {
     if (translationUtil == null) {
-      translationUtil = new TranslationUtil(providesOntologyDAO());
+      translationUtil = new TranslationUtil(jdbi);
     }
     return translationUtil;
   }
 
   @Provides
   @Singleton
-  synchronized DataUseUtil providesDataUseUtil() {
+  private synchronized DataUseUtil providesDataUseUtil() {
     if (dataUseUtil == null) {
       dataUseUtil = new DataUseUtil(providesOntologyService());
     }
@@ -941,7 +933,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized DataUseMatcherV4 providesDataUseMatcherV4() {
+  private synchronized DataUseMatcherV4 providesDataUseMatcherV4() {
     if (dataUseMatcherV4 == null) {
       dataUseMatcherV4 = new DataUseMatcherV4(providesDataUseUtil());
     }
@@ -950,7 +942,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized CountryValidator providesCountryValidator() {
+  private synchronized CountryValidator providesCountryValidator() {
     if (countryValidator == null) {
       countryValidator = new CountryValidator();
     }
@@ -959,7 +951,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized InstitutionUtil providesInstitutionUtil() {
+  private synchronized InstitutionUtil providesInstitutionUtil() {
     if (institutionUtil == null) {
       institutionUtil = new InstitutionUtil();
     }
@@ -968,7 +960,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized JsonSchemaUtil providesJsonSchemaUtil() {
+  private synchronized JsonSchemaUtil providesJsonSchemaUtil() {
     if (jsonSchemaUtil == null) {
       jsonSchemaUtil = new JsonSchemaUtil();
     }
@@ -977,7 +969,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  synchronized TicketFactory providesTicketFactory() {
+  private synchronized TicketFactory providesTicketFactory() {
     if (ticketFactory == null) {
       ticketFactory = new TicketFactory();
     }

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -117,69 +117,6 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   private final DraftDAO draftDAO;
   private final ExecutorService executorService;
 
-  // Lazily-memoized singletons. @Singleton on a @Provides method only covers resolution
-  // through Guice; providers in this module also call each other directly, which bypasses
-  // Guice scoping, so these fields guarantee a single instance on both paths.
-  private ElasticSearchConfiguration elasticSearchConfiguration;
-  private MailConfiguration mailConfiguration;
-  private ServicesConfiguration servicesConfiguration;
-  private OidcConfiguration oidcConfiguration;
-  private ClaimsCache claimsCache;
-  private TranslationUtil translationUtil;
-  private DataUseUtil dataUseUtil;
-  private DataUseMatcherV4 dataUseMatcherV4;
-  private CountryValidator countryValidator;
-  private InstitutionUtil institutionUtil;
-  private JsonSchemaUtil jsonSchemaUtil;
-  private TicketFactory ticketFactory;
-  private OntologyService ontologyService;
-  private DatasetRegistrationService datasetRegistrationService;
-  private InstitutionAndLibraryCardEnforcement institutionAndLibraryCardEnforcement;
-  private SamDAO samDAO;
-  private EmailService emailService;
-  private ElasticSearchService elasticSearchService;
-  private DatasetServiceDAO datasetServiceDAO;
-  private VoteService voteService;
-  private DatasetService datasetService;
-  private UserService userService;
-  private InstitutionService institutionService;
-  private LibraryCardService libraryCardService;
-  private DacService dacService;
-  private DaaService daaService;
-  private CounterService counterService;
-  private VoteServiceDAO voteServiceDAO;
-  private DaaServiceDAO daaServiceDAO;
-  private DacServiceDAO dacServiceDAO;
-  private DarCollectionServiceDAO darCollectionServiceDAO;
-  private DataAccessRequestServiceDAO dataAccessRequestServiceDAO;
-  private DataAccessRequestService dataAccessRequestService;
-  private UserServiceDAO userServiceDAO;
-  private DACAutomationRuleService ruleService;
-  private GCSService gcsService;
-  private SendGridAPI sendGridAPI;
-  private FreeMarkerTemplateHelper freeMarkerTemplateHelper;
-  private DarCollectionService darCollectionService;
-  private FileStorageObjectService fileStorageObjectService;
-  private ElectionService electionService;
-  private FeatureFlagService featureFlagService;
-  private MatchService matchService;
-  private MetricsService metricsService;
-  private NihService nihService;
-  private NihServiceDAO nihServiceDAO;
-  private AcknowledgementService acknowledgementService;
-  private DraftFileStorageServiceDAO draftFileStorageServiceDAO;
-  private DraftServiceDAO draftServiceDAO;
-  private HttpClientUtil httpClientUtil;
-  private OntologyIndexService ontologyIndexService;
-  private SamService samService;
-  private OidcAuthorityDAO oidcAuthorityDAO;
-  private OidcService oidcService;
-  private SupportRequestService supportRequestService;
-  private UseRestrictionConverter useRestrictionConverter;
-  private AuthorizationHelper authorizationHelper;
-  private OAuthAuthenticator oauthAuthenticator;
-  private DuosUserAuthenticator duosUserAuthenticator;
-
   ConsentModule(ConsentConfiguration consentConfiguration, Environment environment) {
     this.config = consentConfiguration;
     this.environment = environment;
@@ -204,8 +141,8 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
     this.userRoleDAO = this.jdbi.onDemand(UserRoleDAO.class);
     this.dataAccessRequestDAO = this.jdbi.onDemand(DataAccessRequestDAO.class);
     this.darCollectionDAO = this.jdbi.onDemand(DarCollectionDAO.class);
-    this.libraryCardDAO = this.jdbi.onDemand((LibraryCardDAO.class));
-    this.fileStorageObjectDAO = this.jdbi.onDemand((FileStorageObjectDAO.class));
+    this.libraryCardDAO = this.jdbi.onDemand(LibraryCardDAO.class);
+    this.fileStorageObjectDAO = this.jdbi.onDemand(FileStorageObjectDAO.class);
     this.draftDAO = this.jdbi.onDemand(DraftDAO.class);
 
     // All async work in this application is blocking I/O (Sam calls, Elasticsearch indexing,
@@ -259,11 +196,8 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  private synchronized HttpClientUtil providesHttpClientUtil() {
-    if (httpClientUtil == null) {
-      httpClientUtil = new HttpClientUtil(config.getServicesConfiguration());
-    }
-    return httpClientUtil;
+  private HttpClientUtil providesHttpClientUtil() {
+    return new HttpClientUtil(config.getServicesConfiguration());
   }
 
   @Provides
@@ -274,29 +208,20 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  private synchronized ElasticSearchConfiguration providesElasticSearchConfiguration() {
-    if (elasticSearchConfiguration == null) {
-      elasticSearchConfiguration = config.getElasticSearchConfiguration();
-    }
-    return elasticSearchConfiguration;
+  private ElasticSearchConfiguration providesElasticSearchConfiguration() {
+    return config.getElasticSearchConfiguration();
   }
 
   @Provides
   @Singleton
-  private synchronized MailConfiguration providesMailConfiguration() {
-    if (mailConfiguration == null) {
-      mailConfiguration = config.getMailConfiguration();
-    }
-    return mailConfiguration;
+  private MailConfiguration providesMailConfiguration() {
+    return config.getMailConfiguration();
   }
 
   @Provides
   @Singleton
-  private synchronized ServicesConfiguration providesServicesConfiguration() {
-    if (servicesConfiguration == null) {
-      servicesConfiguration = config.getServicesConfiguration();
-    }
-    return servicesConfiguration;
+  private ServicesConfiguration providesServicesConfiguration() {
+    return config.getServicesConfiguration();
   }
 
   @Provides
@@ -307,244 +232,14 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  private synchronized UseRestrictionConverter providesUseRestrictionConverter() {
-    if (useRestrictionConverter == null) {
-      useRestrictionConverter = new UseRestrictionConverter();
-    }
-    return useRestrictionConverter;
+  private OidcConfiguration providesOidcConfiguration() {
+    return config.getOidcConfiguration();
   }
 
   @Provides
   @Singleton
-  private synchronized OntologyService providesOntologyService() {
-    if (ontologyService == null) {
-      ontologyService =
-          new OntologyService(
-              jdbi,
-              providesOntologyIndexService(),
-              providesExecutorService(),
-              providesTranslationUtil());
-    }
-    return ontologyService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized OntologyIndexService providesOntologyIndexService() {
-    if (ontologyIndexService == null) {
-      ontologyIndexService =
-          new OntologyIndexService(providesGCSService(), config.getCloudStoreConfiguration());
-    }
-    return ontologyIndexService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized AuthorizationHelper providesAuthorizationHelper() {
-    if (authorizationHelper == null) {
-      authorizationHelper =
-          new AuthorizationHelper(
-              providesSamService(), providesUserService(), providesClaimsCache());
-    }
-    return authorizationHelper;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized OAuthAuthenticator providesOAuthAuthenticator() {
-    if (oauthAuthenticator == null) {
-      oauthAuthenticator = new OAuthAuthenticator(providesAuthorizationHelper());
-    }
-    return oauthAuthenticator;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DuosUserAuthenticator providesDuosUserOAuthAuthenticator() {
-    if (duosUserAuthenticator == null) {
-      duosUserAuthenticator = new DuosUserAuthenticator(providesAuthorizationHelper());
-    }
-    return duosUserAuthenticator;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DarCollectionService providesDarCollectionService() {
-    if (darCollectionService == null) {
-      darCollectionService =
-          new DarCollectionService(
-              providesJdbi(),
-              providesDarCollectionServiceDAO(),
-              providesEmailService(),
-              providesRuleService());
-    }
-    return darCollectionService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized FileStorageObjectService providesFileStorageObjectService() {
-    if (fileStorageObjectService == null) {
-      fileStorageObjectService =
-          new FileStorageObjectService(
-              providesJdbi(),
-              providesGCSService(),
-              providesDatasetService(),
-              providesDacService(),
-              providesDaaService(),
-              providesDataAccessRequestService());
-    }
-    return fileStorageObjectService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized GCSService providesGCSService() {
-    if (gcsService == null) {
-      gcsService = new GCSService(config.getCloudStoreConfiguration());
-    }
-    return gcsService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized CounterService providesCounterService() {
-    if (counterService == null) {
-      counterService = new CounterService(providesJdbi());
-    }
-    return counterService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DACAutomationRuleService providesRuleService() {
-    if (ruleService == null) {
-      ruleService =
-          new DACAutomationRuleService(
-              providesJdbi(), providesVoteServiceDAO(), providesVoteService());
-    }
-    return ruleService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DataAccessRequestService providesDataAccessRequestService() {
-    if (dataAccessRequestService == null) {
-      dataAccessRequestService =
-          new DataAccessRequestService(
-              providesJdbi(),
-              providesDataAccessRequestServiceDAO(),
-              providesCounterService(),
-              providesDacService(),
-              providesUserService(),
-              providesInstitutionService(),
-              providesEmailService(),
-              providesRuleService(),
-              providesCountryValidator(),
-              config);
-    }
-    return dataAccessRequestService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DatasetServiceDAO providesDatasetServiceDAO() {
-    if (datasetServiceDAO == null) {
-      datasetServiceDAO = new DatasetServiceDAO(providesJdbi());
-    }
-    return datasetServiceDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DatasetService providesDatasetService() {
-    if (datasetService == null) {
-      datasetService =
-          new DatasetService(
-              providesJdbi(),
-              providesDatasetServiceDAO(),
-              providesElasticSearchService(),
-              providesEmailService(),
-              providesOntologyService());
-    }
-    return datasetService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized ElectionService providesElectionService() {
-    if (electionService == null) {
-      electionService = new ElectionService(providesJdbi());
-    }
-    return electionService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized FreeMarkerTemplateHelper providesFreeMarkerTemplateHelper() {
-    if (freeMarkerTemplateHelper == null) {
-      freeMarkerTemplateHelper = new FreeMarkerTemplateHelper(config.getFreeMarkerConfiguration());
-    }
-    return freeMarkerTemplateHelper;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized EmailService providesEmailService() {
-    if (emailService == null) {
-      emailService =
-          new EmailService(
-              providesJdbi(), providesSendGridAPI(), providesFreeMarkerTemplateHelper(), config);
-    }
-    return emailService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized FeatureFlagService providesFeatureFlagService() {
-    if (featureFlagService == null) {
-      featureFlagService = new FeatureFlagService(providesJdbi());
-    }
-    return featureFlagService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized SendGridAPI providesSendGridAPI() {
-    if (sendGridAPI == null) {
-      sendGridAPI = new SendGridAPI(config.getMailConfiguration(), providesJdbi());
-    }
-    return sendGridAPI;
-  }
-
-  @Provides
-  @Singleton
-  private DataAccessRequestDAO providesDataAccessRequestDAO() {
-    return dataAccessRequestDAO;
-  }
-
-  @Provides
-  @Singleton
-  private DarCollectionDAO providesDARCollectionDAO() {
-    return darCollectionDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DarCollectionServiceDAO providesDarCollectionServiceDAO() {
-    if (darCollectionServiceDAO == null) {
-      darCollectionServiceDAO = new DarCollectionServiceDAO(providesJdbi());
-    }
-    return darCollectionServiceDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DataAccessRequestServiceDAO providesDataAccessRequestServiceDAO() {
-    if (dataAccessRequestServiceDAO == null) {
-      dataAccessRequestServiceDAO = new DataAccessRequestServiceDAO(providesJdbi());
-    }
-    return dataAccessRequestServiceDAO;
+  private UseRestrictionConverter providesUseRestrictionConverter() {
+    return new UseRestrictionConverter();
   }
 
   @Provides
@@ -567,25 +262,8 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  private synchronized VoteServiceDAO providesVoteServiceDAO() {
-    if (voteServiceDAO == null) {
-      voteServiceDAO = new VoteServiceDAO(providesJdbi());
-    }
-    return voteServiceDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized VoteService providesVoteService() {
-    if (voteService == null) {
-      voteService =
-          new VoteService(
-              providesJdbi(),
-              providesVoteServiceDAO(),
-              providesEmailService(),
-              providesOntologyService());
-    }
-    return voteService;
+  private DatasetDAO providesDatasetDAO() {
+    return datasetDAO;
   }
 
   @Provides
@@ -596,78 +274,8 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  private DatasetDAO providesDatasetDAO() {
-    return datasetDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DaaServiceDAO providesDaaServiceDAO() {
-    if (daaServiceDAO == null) {
-      daaServiceDAO = new DaaServiceDAO(providesJdbi());
-    }
-    return daaServiceDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DacServiceDAO providesDacServiceDAO() {
-    if (dacServiceDAO == null) {
-      dacServiceDAO = new DacServiceDAO(providesJdbi());
-    }
-    return dacServiceDAO;
-  }
-
-  @Provides
-  @Singleton
   private DaaDAO providesDaaDAO() {
     return daaDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DaaService providesDaaService() {
-    if (daaService == null) {
-      daaService =
-          new DaaService(
-              providesJdbi(),
-              providesDaaServiceDAO(),
-              providesGCSService(),
-              providesEmailService(),
-              providesUserService(),
-              providesLibraryCardService());
-    }
-    return daaService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DacService providesDacService() {
-    if (dacService == null) {
-      dacService =
-          new DacService(
-              providesJdbi(),
-              providesDacServiceDAO(),
-              providesVoteService(),
-              providesElasticSearchService(),
-              providesDaaService());
-    }
-    return dacService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized ElasticSearchService providesElasticSearchService() {
-    if (elasticSearchService == null) {
-      elasticSearchService =
-          new ElasticSearchService(
-              providesJdbi(),
-              providesDatasetServiceDAO(),
-              ElasticSearchSupport.createRestClient(config.getElasticSearchConfiguration()),
-              config.getElasticSearchConfiguration(),
-              providesOntologyService());
-    }
-    return elasticSearchService;
   }
 
   @Provides
@@ -684,28 +292,14 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  private synchronized MatchService providesMatchService() {
-    if (matchService == null) {
-      matchService =
-          new MatchService(
-              providesJdbi(), providesUseRestrictionConverter(), providesDataUseMatcherV4());
-    }
-    return matchService;
+  private DataAccessRequestDAO providesDataAccessRequestDAO() {
+    return dataAccessRequestDAO;
   }
 
   @Provides
   @Singleton
-  private synchronized MetricsService providesMetricsService() {
-    if (metricsService == null) {
-      metricsService = new MetricsService(providesJdbi());
-    }
-    return metricsService;
-  }
-
-  @Provides
-  @Singleton
-  private FileStorageObjectDAO providesFileStorageObjectDAO() {
-    return fileStorageObjectDAO;
+  private DarCollectionDAO providesDARCollectionDAO() {
+    return darCollectionDAO;
   }
 
   @Provides
@@ -716,167 +310,8 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  private synchronized InstitutionService providesInstitutionService() {
-    if (institutionService == null) {
-      institutionService =
-          new InstitutionService(providesJdbi(), providesInstitutionAndLibraryCardEnforcement());
-    }
-    return institutionService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized LibraryCardService providesLibraryCardService() {
-    if (libraryCardService == null) {
-      libraryCardService =
-          new LibraryCardService(
-              providesJdbi(), providesInstitutionService(), providesEmailService());
-    }
-    return libraryCardService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized AcknowledgementService providesAcknowledgementService() {
-    if (acknowledgementService == null) {
-      acknowledgementService = new AcknowledgementService(providesJdbi(), providesEmailService());
-    }
-    return acknowledgementService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized DatasetRegistrationService providesDatasetRegistrationService() {
-    if (datasetRegistrationService == null) {
-      datasetRegistrationService =
-          new DatasetRegistrationService(
-              providesJdbi(),
-              providesDatasetServiceDAO(),
-              providesGCSService(),
-              providesElasticSearchService(),
-              providesEmailService(),
-              providesExecutorService());
-    }
-    return datasetRegistrationService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized UserServiceDAO providesUserServiceDAO() {
-    if (userServiceDAO == null) {
-      userServiceDAO = new UserServiceDAO(providesJdbi());
-    }
-    return userServiceDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized UserService providesUserService() {
-    if (userService == null) {
-      userService =
-          new UserService(
-              providesJdbi(),
-              providesUserServiceDAO(),
-              providesInstitutionService(),
-              providesInstitutionAndLibraryCardEnforcement());
-    }
-    return userService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized InstitutionAndLibraryCardEnforcement
-      providesInstitutionAndLibraryCardEnforcement() {
-    if (institutionAndLibraryCardEnforcement == null) {
-      institutionAndLibraryCardEnforcement =
-          new InstitutionAndLibraryCardEnforcement(
-              providesJdbi(), providesUserServiceDAO(), providesExecutorService());
-    }
-    return institutionAndLibraryCardEnforcement;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized NihService providesNihService() {
-    if (nihService == null) {
-      nihService =
-          new NihService(
-              providesJdbi(),
-              providesNIHServiceDAO(),
-              providesHttpClientUtil(),
-              config.getServicesConfiguration());
-    }
-    return nihService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized NihServiceDAO providesNIHServiceDAO() {
-    if (nihServiceDAO == null) {
-      nihServiceDAO = new NihServiceDAO(providesJdbi());
-    }
-    return nihServiceDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized SamService providesSamService() {
-    if (samService == null) {
-      samService = new SamService(providesSamDAO());
-    }
-    return samService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized SamDAO providesSamDAO() {
-    if (samDAO == null) {
-      samDAO =
-          new SamDAO(
-              providesHttpClientUtil(),
-              config.getServicesConfiguration(),
-              providesExecutorService());
-    }
-    return samDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized OidcConfiguration providesOidcConfiguration() {
-    if (oidcConfiguration == null) {
-      oidcConfiguration = config.getOidcConfiguration();
-    }
-    return oidcConfiguration;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized OidcAuthorityDAO providesOidcAuthorityDAO() {
-    if (oidcAuthorityDAO == null) {
-      oidcAuthorityDAO =
-          new OidcAuthorityDAO(providesHttpClientUtil(), providesOidcConfiguration());
-    }
-    return oidcAuthorityDAO;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized OidcService providesOidcService() {
-    if (oidcService == null) {
-      oidcService = new OidcService(providesOidcAuthorityDAO(), providesOidcConfiguration());
-    }
-    return oidcService;
-  }
-
-  @Provides
-  @Singleton
-  private synchronized SupportRequestService providesSupportRequestService() {
-    if (supportRequestService == null) {
-      supportRequestService =
-          new SupportRequestService(
-              providesHttpClientUtil(), providesTicketFactory(), providesServicesConfiguration());
-    }
-    return supportRequestService;
+  private FileStorageObjectDAO providesFileStorageObjectDAO() {
+    return fileStorageObjectDAO;
   }
 
   @Provides
@@ -887,92 +322,420 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
 
   @Provides
   @Singleton
-  private synchronized DraftFileStorageServiceDAO providesDraftFileStorageService() {
-    if (draftFileStorageServiceDAO == null) {
-      draftFileStorageServiceDAO =
-          new DraftFileStorageServiceDAO(providesJdbi(), providesGCSService());
-    }
-    return draftFileStorageServiceDAO;
+  private TranslationUtil providesTranslationUtil(Jdbi jdbi) {
+    return new TranslationUtil(jdbi);
   }
 
   @Provides
   @Singleton
-  private synchronized DraftServiceDAO providesDraftServiceDAO() {
-    if (draftServiceDAO == null) {
-      draftServiceDAO = new DraftServiceDAO(providesJdbi(), providesDraftFileStorageService());
-    }
-    return draftServiceDAO;
+  private GCSService providesGCSService() {
+    return new GCSService(config.getCloudStoreConfiguration());
   }
 
   @Provides
   @Singleton
-  private synchronized ClaimsCache providesClaimsCache() {
-    if (claimsCache == null) {
-      claimsCache = new ClaimsCache();
-    }
-    return claimsCache;
+  private OntologyIndexService providesOntologyIndexService(GCSService gcsService) {
+    return new OntologyIndexService(gcsService, config.getCloudStoreConfiguration());
   }
 
   @Provides
   @Singleton
-  private synchronized TranslationUtil providesTranslationUtil() {
-    if (translationUtil == null) {
-      translationUtil = new TranslationUtil(jdbi);
-    }
-    return translationUtil;
+  private OntologyService providesOntologyService(
+      Jdbi jdbi,
+      OntologyIndexService indexService,
+      ExecutorService executorService,
+      TranslationUtil translationUtil) {
+    return new OntologyService(jdbi, indexService, executorService, translationUtil);
   }
 
   @Provides
   @Singleton
-  private synchronized DataUseUtil providesDataUseUtil() {
-    if (dataUseUtil == null) {
-      dataUseUtil = new DataUseUtil(providesOntologyService());
-    }
-    return dataUseUtil;
+  private DataUseUtil providesDataUseUtil(OntologyService ontologyService) {
+    return new DataUseUtil(ontologyService);
   }
 
   @Provides
   @Singleton
-  private synchronized DataUseMatcherV4 providesDataUseMatcherV4() {
-    if (dataUseMatcherV4 == null) {
-      dataUseMatcherV4 = new DataUseMatcherV4(providesDataUseUtil());
-    }
-    return dataUseMatcherV4;
+  private DataUseMatcherV4 providesDataUseMatcherV4(DataUseUtil dataUseUtil) {
+    return new DataUseMatcherV4(dataUseUtil);
   }
 
   @Provides
   @Singleton
-  private synchronized CountryValidator providesCountryValidator() {
-    if (countryValidator == null) {
-      countryValidator = new CountryValidator();
-    }
-    return countryValidator;
+  private ElasticSearchService providesElasticSearchService(
+      Jdbi jdbi,
+      DatasetServiceDAO datasetServiceDAO,
+      ElasticSearchConfiguration elasticSearchConfiguration,
+      OntologyService ontologyService) {
+    return new ElasticSearchService(
+        jdbi,
+        datasetServiceDAO,
+        ElasticSearchSupport.createRestClient(elasticSearchConfiguration),
+        elasticSearchConfiguration,
+        ontologyService);
   }
 
   @Provides
   @Singleton
-  private synchronized InstitutionUtil providesInstitutionUtil() {
-    if (institutionUtil == null) {
-      institutionUtil = new InstitutionUtil();
-    }
-    return institutionUtil;
+  private FreeMarkerTemplateHelper providesFreeMarkerTemplateHelper() {
+    return new FreeMarkerTemplateHelper(config.getFreeMarkerConfiguration());
   }
 
   @Provides
   @Singleton
-  private synchronized JsonSchemaUtil providesJsonSchemaUtil() {
-    if (jsonSchemaUtil == null) {
-      jsonSchemaUtil = new JsonSchemaUtil();
-    }
-    return jsonSchemaUtil;
+  private SendGridAPI providesSendGridAPI(Jdbi jdbi, MailConfiguration mailConfiguration) {
+    return new SendGridAPI(mailConfiguration, jdbi);
   }
 
   @Provides
   @Singleton
-  private synchronized TicketFactory providesTicketFactory() {
-    if (ticketFactory == null) {
-      ticketFactory = new TicketFactory();
-    }
-    return ticketFactory;
+  private EmailService providesEmailService(
+      Jdbi jdbi, SendGridAPI sendGridAPI, FreeMarkerTemplateHelper freeMarkerTemplateHelper) {
+    return new EmailService(jdbi, sendGridAPI, freeMarkerTemplateHelper, config);
+  }
+
+  @Provides
+  @Singleton
+  private SamDAO providesSamDAO(
+      HttpClientUtil httpClientUtil,
+      ServicesConfiguration servicesConfiguration,
+      ExecutorService executorService) {
+    return new SamDAO(httpClientUtil, servicesConfiguration, executorService);
+  }
+
+  @Provides
+  @Singleton
+  private SamService providesSamService(SamDAO samDAO) {
+    return new SamService(samDAO);
+  }
+
+  @Provides
+  @Singleton
+  private OidcAuthorityDAO providesOidcAuthorityDAO(
+      HttpClientUtil httpClientUtil, OidcConfiguration oidcConfiguration) {
+    return new OidcAuthorityDAO(httpClientUtil, oidcConfiguration);
+  }
+
+  @Provides
+  @Singleton
+  private OidcService providesOidcService(
+      OidcAuthorityDAO oidcAuthorityDAO, OidcConfiguration oidcConfiguration) {
+    return new OidcService(oidcAuthorityDAO, oidcConfiguration);
+  }
+
+  @Provides
+  @Singleton
+  private ClaimsCache providesClaimsCache() {
+    return new ClaimsCache();
+  }
+
+  @Provides
+  @Singleton
+  private AuthorizationHelper providesAuthorizationHelper(
+      SamService samService, UserService userService, ClaimsCache claimsCache) {
+    return new AuthorizationHelper(samService, userService, claimsCache);
+  }
+
+  @Provides
+  @Singleton
+  private OAuthAuthenticator providesOAuthAuthenticator(AuthorizationHelper authorizationHelper) {
+    return new OAuthAuthenticator(authorizationHelper);
+  }
+
+  @Provides
+  @Singleton
+  private DuosUserAuthenticator providesDuosUserOAuthAuthenticator(
+      AuthorizationHelper authorizationHelper) {
+    return new DuosUserAuthenticator(authorizationHelper);
+  }
+
+  @Provides
+  @Singleton
+  private DatasetServiceDAO providesDatasetServiceDAO(Jdbi jdbi) {
+    return new DatasetServiceDAO(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private VoteServiceDAO providesVoteServiceDAO(Jdbi jdbi) {
+    return new VoteServiceDAO(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private DarCollectionServiceDAO providesDarCollectionServiceDAO(Jdbi jdbi) {
+    return new DarCollectionServiceDAO(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private DataAccessRequestServiceDAO providesDataAccessRequestServiceDAO(Jdbi jdbi) {
+    return new DataAccessRequestServiceDAO(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private DaaServiceDAO providesDaaServiceDAO(Jdbi jdbi) {
+    return new DaaServiceDAO(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private DacServiceDAO providesDacServiceDAO(Jdbi jdbi) {
+    return new DacServiceDAO(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private NihServiceDAO providesNIHServiceDAO(Jdbi jdbi) {
+    return new NihServiceDAO(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private UserServiceDAO providesUserServiceDAO(Jdbi jdbi) {
+    return new UserServiceDAO(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private DraftFileStorageServiceDAO providesDraftFileStorageService(
+      Jdbi jdbi, GCSService gcsService) {
+    return new DraftFileStorageServiceDAO(jdbi, gcsService);
+  }
+
+  @Provides
+  @Singleton
+  private DraftServiceDAO providesDraftServiceDAO(
+      Jdbi jdbi, DraftFileStorageServiceDAO draftFileStorageServiceDAO) {
+    return new DraftServiceDAO(jdbi, draftFileStorageServiceDAO);
+  }
+
+  @Provides
+  @Singleton
+  private ElectionService providesElectionService(Jdbi jdbi) {
+    return new ElectionService(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private FeatureFlagService providesFeatureFlagService(Jdbi jdbi) {
+    return new FeatureFlagService(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private CounterService providesCounterService(Jdbi jdbi) {
+    return new CounterService(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private MetricsService providesMetricsService(Jdbi jdbi) {
+    return new MetricsService(jdbi);
+  }
+
+  @Provides
+  @Singleton
+  private InstitutionAndLibraryCardEnforcement providesInstitutionAndLibraryCardEnforcement(
+      Jdbi jdbi, UserServiceDAO userServiceDAO, ExecutorService executorService) {
+    return new InstitutionAndLibraryCardEnforcement(jdbi, userServiceDAO, executorService);
+  }
+
+  @Provides
+  @Singleton
+  private InstitutionService providesInstitutionService(
+      Jdbi jdbi, InstitutionAndLibraryCardEnforcement enforcement) {
+    return new InstitutionService(jdbi, enforcement);
+  }
+
+  @Provides
+  @Singleton
+  private LibraryCardService providesLibraryCardService(
+      Jdbi jdbi, InstitutionService institutionService, EmailService emailService) {
+    return new LibraryCardService(jdbi, institutionService, emailService);
+  }
+
+  @Provides
+  @Singleton
+  private UserService providesUserService(
+      Jdbi jdbi,
+      UserServiceDAO userServiceDAO,
+      InstitutionService institutionService,
+      InstitutionAndLibraryCardEnforcement enforcement) {
+    return new UserService(jdbi, userServiceDAO, institutionService, enforcement);
+  }
+
+  @Provides
+  @Singleton
+  private AcknowledgementService providesAcknowledgementService(
+      Jdbi jdbi, EmailService emailService) {
+    return new AcknowledgementService(jdbi, emailService);
+  }
+
+  @Provides
+  @Singleton
+  private VoteService providesVoteService(
+      Jdbi jdbi,
+      VoteServiceDAO voteServiceDAO,
+      EmailService emailService,
+      OntologyService ontologyService) {
+    return new VoteService(jdbi, voteServiceDAO, emailService, ontologyService);
+  }
+
+  @Provides
+  @Singleton
+  private DACAutomationRuleService providesRuleService(
+      Jdbi jdbi, VoteServiceDAO voteServiceDAO, VoteService voteService) {
+    return new DACAutomationRuleService(jdbi, voteServiceDAO, voteService);
+  }
+
+  @Provides
+  @Singleton
+  private DaaService providesDaaService(
+      Jdbi jdbi,
+      DaaServiceDAO daaServiceDAO,
+      GCSService gcsService,
+      EmailService emailService,
+      UserService userService,
+      LibraryCardService libraryCardService) {
+    return new DaaService(
+        jdbi, daaServiceDAO, gcsService, emailService, userService, libraryCardService);
+  }
+
+  @Provides
+  @Singleton
+  private DacService providesDacService(
+      Jdbi jdbi,
+      DacServiceDAO dacServiceDAO,
+      VoteService voteService,
+      ElasticSearchService elasticSearchService,
+      DaaService daaService) {
+    return new DacService(jdbi, dacServiceDAO, voteService, elasticSearchService, daaService);
+  }
+
+  @Provides
+  @Singleton
+  private DatasetService providesDatasetService(
+      Jdbi jdbi,
+      DatasetServiceDAO datasetServiceDAO,
+      ElasticSearchService elasticSearchService,
+      EmailService emailService,
+      OntologyService ontologyService) {
+    return new DatasetService(
+        jdbi, datasetServiceDAO, elasticSearchService, emailService, ontologyService);
+  }
+
+  @Provides
+  @Singleton
+  private DataAccessRequestService providesDataAccessRequestService(
+      Jdbi jdbi,
+      DataAccessRequestServiceDAO dataAccessRequestServiceDAO,
+      CounterService counterService,
+      DacService dacService,
+      UserService userService,
+      InstitutionService institutionService,
+      EmailService emailService,
+      DACAutomationRuleService ruleService,
+      CountryValidator countryValidator) {
+    return new DataAccessRequestService(
+        jdbi,
+        dataAccessRequestServiceDAO,
+        counterService,
+        dacService,
+        userService,
+        institutionService,
+        emailService,
+        ruleService,
+        countryValidator,
+        config);
+  }
+
+  @Provides
+  @Singleton
+  private DarCollectionService providesDarCollectionService(
+      Jdbi jdbi,
+      DarCollectionServiceDAO darCollectionServiceDAO,
+      EmailService emailService,
+      DACAutomationRuleService ruleService) {
+    return new DarCollectionService(jdbi, darCollectionServiceDAO, emailService, ruleService);
+  }
+
+  @Provides
+  @Singleton
+  private FileStorageObjectService providesFileStorageObjectService(
+      Jdbi jdbi,
+      GCSService gcsService,
+      DatasetService datasetService,
+      DacService dacService,
+      DaaService daaService,
+      DataAccessRequestService dataAccessRequestService) {
+    return new FileStorageObjectService(
+        jdbi, gcsService, datasetService, dacService, daaService, dataAccessRequestService);
+  }
+
+  @Provides
+  @Singleton
+  private DatasetRegistrationService providesDatasetRegistrationService(
+      Jdbi jdbi,
+      DatasetServiceDAO datasetServiceDAO,
+      GCSService gcsService,
+      ElasticSearchService elasticSearchService,
+      EmailService emailService,
+      ExecutorService executorService) {
+    return new DatasetRegistrationService(
+        jdbi, datasetServiceDAO, gcsService, elasticSearchService, emailService, executorService);
+  }
+
+  @Provides
+  @Singleton
+  private MatchService providesMatchService(
+      Jdbi jdbi,
+      UseRestrictionConverter useRestrictionConverter,
+      DataUseMatcherV4 dataUseMatcherV4) {
+    return new MatchService(jdbi, useRestrictionConverter, dataUseMatcherV4);
+  }
+
+  @Provides
+  @Singleton
+  private NihService providesNihService(
+      Jdbi jdbi,
+      NihServiceDAO nihServiceDAO,
+      HttpClientUtil httpClientUtil,
+      ServicesConfiguration servicesConfiguration) {
+    return new NihService(jdbi, nihServiceDAO, httpClientUtil, servicesConfiguration);
+  }
+
+  @Provides
+  @Singleton
+  private SupportRequestService providesSupportRequestService(
+      HttpClientUtil httpClientUtil,
+      TicketFactory ticketFactory,
+      ServicesConfiguration servicesConfiguration) {
+    return new SupportRequestService(httpClientUtil, ticketFactory, servicesConfiguration);
+  }
+
+  @Provides
+  @Singleton
+  private CountryValidator providesCountryValidator() {
+    return new CountryValidator();
+  }
+
+  @Provides
+  @Singleton
+  private InstitutionUtil providesInstitutionUtil() {
+    return new InstitutionUtil();
+  }
+
+  @Provides
+  @Singleton
+  private JsonSchemaUtil providesJsonSchemaUtil() {
+    return new JsonSchemaUtil();
+  }
+
+  @Provides
+  @Singleton
+  private TicketFactory providesTicketFactory() {
+    return new TicketFactory();
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -37,8 +37,13 @@ import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.filters.ClaimsCache;
 import org.broadinstitute.consent.http.mail.SendGridAPI;
 import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
+import org.broadinstitute.consent.http.matching.DataUseMatcherV4;
+import org.broadinstitute.consent.http.matching.DataUseUtil;
+import org.broadinstitute.consent.http.matching.TranslationUtil;
+import org.broadinstitute.consent.http.models.support.TicketFactory;
 import org.broadinstitute.consent.http.service.AcknowledgementService;
 import org.broadinstitute.consent.http.service.CounterService;
 import org.broadinstitute.consent.http.service.DACAutomationRuleService;
@@ -76,10 +81,14 @@ import org.broadinstitute.consent.http.service.dao.UserServiceDAO;
 import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.broadinstitute.consent.http.service.feature.InstitutionAndLibraryCardEnforcement;
 import org.broadinstitute.consent.http.service.ontology.ElasticSearchSupport;
+import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.broadinstitute.consent.http.util.CountryValidator;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.InstitutionUtil;
+import org.broadinstitute.consent.http.util.JsonSchemaUtil;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.gson2.Gson2Config;
@@ -107,11 +116,24 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   private final LibraryCardDAO libraryCardDAO;
   private final FileStorageObjectDAO fileStorageObjectDAO;
   private final DraftDAO draftDAO;
+  private final OntologyDAO ontologyDAO;
   private final ExecutorService executorService;
 
   // Lazily-memoized singletons. @Singleton on a @Provides method only covers resolution
   // through Guice; providers in this module also call each other directly, which bypasses
   // Guice scoping, so these fields guarantee a single instance on both paths.
+  private ElasticSearchConfiguration elasticSearchConfiguration;
+  private MailConfiguration mailConfiguration;
+  private ServicesConfiguration servicesConfiguration;
+  private OidcConfiguration oidcConfiguration;
+  private ClaimsCache claimsCache;
+  private TranslationUtil translationUtil;
+  private DataUseUtil dataUseUtil;
+  private DataUseMatcherV4 dataUseMatcherV4;
+  private CountryValidator countryValidator;
+  private InstitutionUtil institutionUtil;
+  private JsonSchemaUtil jsonSchemaUtil;
+  private TicketFactory ticketFactory;
   private OntologyService ontologyService;
   private DatasetRegistrationService datasetRegistrationService;
   private InstitutionAndLibraryCardEnforcement institutionAndLibraryCardEnforcement;
@@ -155,6 +177,10 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   private OidcAuthorityDAO oidcAuthorityDAO;
   private OidcService oidcService;
   private SupportRequestService supportRequestService;
+  private UseRestrictionConverter useRestrictionConverter;
+  private AuthorizationHelper authorizationHelper;
+  private OAuthAuthenticator oauthAuthenticator;
+  private DuosUserAuthenticator duosUserAuthenticator;
 
   ConsentModule(ConsentConfiguration consentConfiguration, Environment environment) {
     this.config = consentConfiguration;
@@ -183,6 +209,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
     this.libraryCardDAO = this.jdbi.onDemand((LibraryCardDAO.class));
     this.fileStorageObjectDAO = this.jdbi.onDemand((FileStorageObjectDAO.class));
     this.draftDAO = this.jdbi.onDemand(DraftDAO.class);
+    this.ontologyDAO = this.jdbi.onDemand(OntologyDAO.class);
 
     // All async work in this application is blocking I/O (Sam calls, Elasticsearch indexing,
     // batch DB writes), so a single shared virtual-thread executor replaces the per-class
@@ -222,11 +249,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
+  @Singleton
   ExecutorService providesExecutorService() {
     return executorService;
   }
 
   @Provides
+  @Singleton
   Client providesClient() {
     return client;
   }
@@ -241,33 +270,51 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
+  @Singleton
   Jdbi providesJdbi() {
     return jdbi;
   }
 
   @Provides
-  ElasticSearchConfiguration providesElasticSearchConfiguration() {
-    return config.getElasticSearchConfiguration();
+  @Singleton
+  synchronized ElasticSearchConfiguration providesElasticSearchConfiguration() {
+    if (elasticSearchConfiguration == null) {
+      elasticSearchConfiguration = config.getElasticSearchConfiguration();
+    }
+    return elasticSearchConfiguration;
   }
 
   @Provides
-  MailConfiguration providesMailConfiguration() {
-    return config.getMailConfiguration();
+  @Singleton
+  synchronized MailConfiguration providesMailConfiguration() {
+    if (mailConfiguration == null) {
+      mailConfiguration = config.getMailConfiguration();
+    }
+    return mailConfiguration;
   }
 
   @Provides
-  ServicesConfiguration providesServicesConfiguration() {
-    return config.getServicesConfiguration();
+  @Singleton
+  synchronized ServicesConfiguration providesServicesConfiguration() {
+    if (servicesConfiguration == null) {
+      servicesConfiguration = config.getServicesConfiguration();
+    }
+    return servicesConfiguration;
   }
 
   @Provides
+  @Singleton
   HealthCheckRegistry providesHealthCheckRegistry() {
     return environment.healthChecks();
   }
 
   @Provides
-  UseRestrictionConverter providesUseRestrictionConverter() {
-    return new UseRestrictionConverter();
+  @Singleton
+  synchronized UseRestrictionConverter providesUseRestrictionConverter() {
+    if (useRestrictionConverter == null) {
+      useRestrictionConverter = new UseRestrictionConverter();
+    }
+    return useRestrictionConverter;
   }
 
   @Provides
@@ -276,7 +323,10 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
     if (ontologyService == null) {
       ontologyService =
           new OntologyService(
-              providesJdbi(), providesOntologyIndexService(), providesExecutorService());
+              providesOntologyDAO(),
+              providesOntologyIndexService(),
+              providesExecutorService(),
+              providesTranslationUtil());
     }
     return ontologyService;
   }
@@ -292,18 +342,32 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
-  AuthorizationHelper providesAuthorizationHelper() {
-    return new AuthorizationHelper(providesSamService(), providesUserService());
+  @Singleton
+  synchronized AuthorizationHelper providesAuthorizationHelper() {
+    if (authorizationHelper == null) {
+      authorizationHelper =
+          new AuthorizationHelper(
+              providesSamService(), providesUserService(), providesClaimsCache());
+    }
+    return authorizationHelper;
   }
 
   @Provides
-  OAuthAuthenticator providesOAuthAuthenticator() {
-    return new OAuthAuthenticator(providesAuthorizationHelper());
+  @Singleton
+  synchronized OAuthAuthenticator providesOAuthAuthenticator() {
+    if (oauthAuthenticator == null) {
+      oauthAuthenticator = new OAuthAuthenticator(providesAuthorizationHelper());
+    }
+    return oauthAuthenticator;
   }
 
   @Provides
-  DuosUserAuthenticator providesDuosUserOAuthAuthenticator() {
-    return new DuosUserAuthenticator(providesAuthorizationHelper());
+  @Singleton
+  synchronized DuosUserAuthenticator providesDuosUserOAuthAuthenticator() {
+    if (duosUserAuthenticator == null) {
+      duosUserAuthenticator = new DuosUserAuthenticator(providesAuthorizationHelper());
+    }
+    return duosUserAuthenticator;
   }
 
   @Provides
@@ -379,6 +443,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
               providesInstitutionService(),
               providesEmailService(),
               providesRuleService(),
+              providesCountryValidator(),
               config);
     }
     return dataAccessRequestService;
@@ -456,11 +521,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
+  @Singleton
   DataAccessRequestDAO providesDataAccessRequestDAO() {
     return dataAccessRequestDAO;
   }
 
   @Provides
+  @Singleton
   DarCollectionDAO providesDARCollectionDAO() {
     return darCollectionDAO;
   }
@@ -484,16 +551,19 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
+  @Singleton
   ElectionDAO providesElectionDAO() {
     return electionDAO;
   }
 
   @Provides
+  @Singleton
   VoteDAO providesVoteDAO() {
     return voteDAO;
   }
 
   @Provides
+  @Singleton
   StudyDAO providesStudyDAO() {
     return studyDAO;
   }
@@ -522,11 +592,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
+  @Singleton
   DatasetAuthorizationReaderDAO providesDatasetAuthorizationReaderDAO() {
     return datasetAuthorizationReaderDAO;
   }
 
   @Provides
+  @Singleton
   DatasetDAO providesDatasetDAO() {
     return datasetDAO;
   }
@@ -550,6 +622,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
+  @Singleton
   DaaDAO providesDaaDAO() {
     return daaDAO;
   }
@@ -601,11 +674,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
+  @Singleton
   UserDAO providesUserDAO() {
     return userDAO;
   }
 
   @Provides
+  @Singleton
   UserRoleDAO providesUserRoleDAO() {
     return userRoleDAO;
   }
@@ -616,7 +691,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
     if (matchService == null) {
       matchService =
           new MatchService(
-              providesJdbi(), providesUseRestrictionConverter(), providesOntologyService());
+              providesJdbi(), providesUseRestrictionConverter(), providesDataUseMatcherV4());
     }
     return matchService;
   }
@@ -631,11 +706,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
+  @Singleton
   FileStorageObjectDAO providesFileStorageObjectDAO() {
     return fileStorageObjectDAO;
   }
 
   @Provides
+  @Singleton
   LibraryCardDAO providesLibraryCardDAO() {
     return libraryCardDAO;
   }
@@ -766,8 +843,12 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   }
 
   @Provides
-  OidcConfiguration providesOidcConfiguration() {
-    return config.getOidcConfiguration();
+  @Singleton
+  synchronized OidcConfiguration providesOidcConfiguration() {
+    if (oidcConfiguration == null) {
+      oidcConfiguration = config.getOidcConfiguration();
+    }
+    return oidcConfiguration;
   }
 
   @Provides
@@ -793,12 +874,15 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   @Singleton
   synchronized SupportRequestService providesSupportRequestService() {
     if (supportRequestService == null) {
-      supportRequestService = new SupportRequestService(config.getServicesConfiguration());
+      supportRequestService =
+          new SupportRequestService(
+              providesHttpClientUtil(), providesTicketFactory(), providesServicesConfiguration());
     }
     return supportRequestService;
   }
 
   @Provides
+  @Singleton
   DraftDAO providesDraftDAO() {
     return draftDAO;
   }
@@ -820,5 +904,83 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
       draftServiceDAO = new DraftServiceDAO(providesJdbi(), providesDraftFileStorageService());
     }
     return draftServiceDAO;
+  }
+
+  @Provides
+  @Singleton
+  OntologyDAO providesOntologyDAO() {
+    return ontologyDAO;
+  }
+
+  @Provides
+  @Singleton
+  synchronized ClaimsCache providesClaimsCache() {
+    if (claimsCache == null) {
+      claimsCache = new ClaimsCache();
+    }
+    return claimsCache;
+  }
+
+  @Provides
+  @Singleton
+  synchronized TranslationUtil providesTranslationUtil() {
+    if (translationUtil == null) {
+      translationUtil = new TranslationUtil(providesOntologyDAO());
+    }
+    return translationUtil;
+  }
+
+  @Provides
+  @Singleton
+  synchronized DataUseUtil providesDataUseUtil() {
+    if (dataUseUtil == null) {
+      dataUseUtil = new DataUseUtil(providesOntologyService());
+    }
+    return dataUseUtil;
+  }
+
+  @Provides
+  @Singleton
+  synchronized DataUseMatcherV4 providesDataUseMatcherV4() {
+    if (dataUseMatcherV4 == null) {
+      dataUseMatcherV4 = new DataUseMatcherV4(providesDataUseUtil());
+    }
+    return dataUseMatcherV4;
+  }
+
+  @Provides
+  @Singleton
+  synchronized CountryValidator providesCountryValidator() {
+    if (countryValidator == null) {
+      countryValidator = new CountryValidator();
+    }
+    return countryValidator;
+  }
+
+  @Provides
+  @Singleton
+  synchronized InstitutionUtil providesInstitutionUtil() {
+    if (institutionUtil == null) {
+      institutionUtil = new InstitutionUtil();
+    }
+    return institutionUtil;
+  }
+
+  @Provides
+  @Singleton
+  synchronized JsonSchemaUtil providesJsonSchemaUtil() {
+    if (jsonSchemaUtil == null) {
+      jsonSchemaUtil = new JsonSchemaUtil();
+    }
+    return jsonSchemaUtil;
+  }
+
+  @Provides
+  @Singleton
+  synchronized TicketFactory providesTicketFactory() {
+    if (ticketFactory == null) {
+      ticketFactory = new TicketFactory();
+    }
+    return ticketFactory;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -323,7 +323,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
     if (ontologyService == null) {
       ontologyService =
           new OntologyService(
-              providesOntologyDAO(),
+              jdbi,
               providesOntologyIndexService(),
               providesExecutorService(),
               providesTranslationUtil());

--- a/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
@@ -27,8 +27,9 @@ public class AuthorizationHelper implements ConsentLogger {
   protected final UserService userService;
 
   @Inject
-  public AuthorizationHelper(SamService samService, UserService userService) {
-    this.claimsCache = ClaimsCache.getInstance();
+  public AuthorizationHelper(
+      SamService samService, UserService userService, ClaimsCache claimsCache) {
+    this.claimsCache = claimsCache;
     this.samService = samService;
     this.userService = userService;
   }

--- a/src/main/java/org/broadinstitute/consent/http/filters/ClaimsCache.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/ClaimsCache.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.filters;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.AbstractMap;
 import java.util.List;
@@ -16,22 +17,15 @@ import java.util.stream.Collectors;
  */
 public class ClaimsCache {
 
-  private static ClaimsCache INSTANCE;
   public final Cache<String, Map<String, String>> cache;
   public static final String OAUTH2_CLAIM_email = "OAUTH2_CLAIM_email";
   public static final String OAUTH2_CLAIM_name = "OAUTH2_CLAIM_name";
   public static final String OAUTH2_CLAIM_access_token = "OAUTH2_CLAIM_access_token";
   public static final String OAUTH2_CLAIM_aud = "OAUTH2_CLAIM_aud";
 
-  private ClaimsCache() {
+  @Inject
+  public ClaimsCache() {
     cache = CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
-  }
-
-  public static ClaimsCache getInstance() {
-    if (INSTANCE == null) {
-      INSTANCE = new ClaimsCache();
-    }
-    return INSTANCE;
   }
 
   private String getFirst(List<String> headerValues) {

--- a/src/main/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilter.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilter.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.filters;
 
+import com.google.inject.Inject;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
@@ -11,7 +12,12 @@ import java.io.IOException;
 @Priority(Integer.MIN_VALUE)
 public class RequestHeaderCacheFilter implements ContainerRequestFilter {
 
-  private final ClaimsCache claimsCache = ClaimsCache.getInstance();
+  private final ClaimsCache claimsCache;
+
+  @Inject
+  public RequestHeaderCacheFilter(ClaimsCache claimsCache) {
+    this.claimsCache = claimsCache;
+  }
 
   @Override
   public void filter(ContainerRequestContext containerRequestContext) throws IOException {

--- a/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
@@ -31,6 +31,8 @@ public class SamHealthCheck extends HealthCheck implements Managed {
         SimpleResponse response = clientUtil.getCachedResponse(httpGet);
         if (response.code() == HttpStatusCodes.STATUS_CODE_OK) {
           String content = response.entity();
+          // TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson
+          // configuration investigation
           SamStatus samStatus = new Gson().fromJson(content, SamStatus.class);
           return Result.builder()
               .withDetail(StatusResource.OK, samStatus.ok)

--- a/src/main/java/org/broadinstitute/consent/http/health/SendGridHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SendGridHealthCheck.java
@@ -30,6 +30,8 @@ public class SendGridHealthCheck extends HealthCheck implements Managed {
         SimpleResponse response = clientUtil.getCachedResponse(httpGet);
         if (response.code() == HttpStatusCodes.STATUS_CODE_OK) {
           String content = response.entity();
+          // TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson
+          // configuration investigation
           SendGridStatus status = new Gson().fromJson(content, SendGridStatus.class);
           return status.getResult();
         } else {

--- a/src/main/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4.java
@@ -16,15 +16,14 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.matching.DataUseMatchResultType;
-import org.broadinstitute.consent.http.service.OntologyService;
 
 public class DataUseMatcherV4 {
 
   private final DataUseUtil dataUseUtil;
 
   @Inject
-  public DataUseMatcherV4(OntologyService ontologyService) {
-    dataUseUtil = new DataUseUtil(ontologyService);
+  public DataUseMatcherV4(DataUseUtil dataUseUtil) {
+    this.dataUseUtil = dataUseUtil;
   }
 
   // Matching Algorithm

--- a/src/main/java/org/broadinstitute/consent/http/matching/DataUseUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/DataUseUtil.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.matching;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
+import com.google.inject.Inject;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -21,6 +22,7 @@ public final class DataUseUtil {
 
   private final OntologyService ontologyService;
 
+  @Inject
   public DataUseUtil(OntologyService ontologyService) {
     this.ontologyService = ontologyService;
   }

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -20,6 +20,7 @@ import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.jdbi.v3.core.Jdbi;
 
 public class TranslationUtil implements ConsentLogger {
 
@@ -60,8 +61,8 @@ public class TranslationUtil implements ConsentLogger {
   private final Gson gson = GsonUtil.getInstance();
 
   @Inject
-  public TranslationUtil(OntologyDAO ontologyDAO) {
-    this.ontologyDAO = ontologyDAO;
+  public TranslationUtil(Jdbi jdbi) {
+    this.ontologyDAO = jdbi.onDemand(OntologyDAO.class);
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.matching;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParser;
+import com.google.inject.Inject;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -58,6 +59,7 @@ public class TranslationUtil implements ConsentLogger {
   private final OntologyDAO ontologyDAO;
   private final Gson gson = GsonUtil.getInstance();
 
+  @Inject
   public TranslationUtil(OntologyDAO ontologyDAO) {
     this.ontologyDAO = ontologyDAO;
   }

--- a/src/main/java/org/broadinstitute/consent/http/models/support/TicketFactory.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/support/TicketFactory.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models.support;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.inject.Inject;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.zendesk.client.v2.model.Ticket;
@@ -12,6 +13,7 @@ public class TicketFactory implements ConsentLogger {
   private static final String REQUEST = "request";
   private static final String SUSPENDED_TICKET = "suspended_ticket";
 
+  @Inject
   public TicketFactory() {
     // public constructor to allow instantiation for instance methods
   }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -418,6 +418,8 @@ public class DaaResource extends Resource implements ConsentLogger {
   @Path("datasets")
   public Response findDaaForDatasets(@Auth DuosUser duosUser, String json) {
     try {
+      // TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson configuration
+      // investigation
       Gson gson = new Gson();
       Type setType = new TypeToken<Set<Integer>>() {}.getType();
       Set<Integer> set = gson.fromJson(json, setType);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -82,14 +82,15 @@ public class DatasetResource extends Resource {
       DatasetRegistrationService datasetRegistrationService,
       ElasticSearchService elasticSearchService,
       TDRService tdrService,
-      GCSService gcsService) {
+      GCSService gcsService,
+      JsonSchemaUtil jsonSchemaUtil) {
     this.datasetService = datasetService;
     this.userService = userService;
     this.datasetRegistrationService = datasetRegistrationService;
     this.gcsService = gcsService;
     this.elasticSearchService = elasticSearchService;
     this.tdrService = tdrService;
-    this.jsonSchemaUtil = new JsonSchemaUtil();
+    this.jsonSchemaUtil = jsonSchemaUtil;
   }
 
   @POST
@@ -459,6 +460,8 @@ public class DatasetResource extends Resource {
       @Auth AuthUser authUser, @PathParam("id") Integer id, String dataUseJson) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
+      // TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson configuration
+      // investigation
       Gson gson = new Gson();
       DataUse dataUse = gson.fromJson(dataUseJson, DataUse.class);
       Dataset originalDataset = datasetService.findDatasetById(user, id);

--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -35,11 +35,13 @@ public class InstitutionResource extends Resource {
     As such, any @PermitAll route would require the entity (Institution) to be formatted with the GsonBuilder
     as opposed to being passed into the response directly.
   */
-  private final InstitutionUtil institutionUtil = new InstitutionUtil();
+  private final InstitutionUtil institutionUtil;
 
   @Inject
-  public InstitutionResource(InstitutionService institutionService) {
+  public InstitutionResource(
+      InstitutionService institutionService, InstitutionUtil institutionUtil) {
     this.institutionService = institutionService;
+    this.institutionUtil = institutionUtil;
   }
 
   @GET

--- a/src/main/java/org/broadinstitute/consent/http/resources/SchemaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/SchemaResource.java
@@ -14,8 +14,8 @@ public class SchemaResource extends Resource {
   private final JsonSchemaUtil jsonSchemaUtil;
 
   @Inject
-  public SchemaResource() {
-    this.jsonSchemaUtil = new JsonSchemaUtil();
+  public SchemaResource(JsonSchemaUtil jsonSchemaUtil) {
+    this.jsonSchemaUtil = jsonSchemaUtil;
   }
 
   @GET

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -84,6 +84,8 @@ public class StudyResource extends Resource {
     try {
       User user = duosUser.getUser();
       Dataset dataset = datasetService.findDatasetByIdentifier(user, datasetIdentifier);
+      // TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson configuration
+      // investigation
       StudyConversion studyConversion = new Gson().fromJson(json, StudyConversion.class);
       Study study = datasetService.convertDatasetToStudy(user, dataset, studyConversion);
       return Response.ok(study).build();
@@ -105,6 +107,8 @@ public class StudyResource extends Resource {
       @Auth AuthUser authUser, @PathParam("studyId") Integer studyId, String json) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
+      // TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson configuration
+      // investigation
       Gson gson = new Gson();
       Type listOfStringObject = new TypeToken<ArrayList<String>>() {}.getType();
       List<String> custodians = gson.fromJson(json, listOfStringObject);

--- a/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
@@ -33,6 +33,8 @@ public class VoteResource extends Resource {
   private final UserService userService;
   private final VoteService voteService;
   private final ElectionService electionService;
+  // TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson configuration
+  // investigation
   private final Gson gson = new Gson();
 
   @Inject
@@ -136,6 +138,8 @@ public class VoteResource extends Resource {
     User user = userService.findUserByEmail(authUser.getEmail());
     Vote.RationaleUpdate update;
     try {
+      // TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson configuration
+      // investigation
       update = new Gson().fromJson(json, Vote.RationaleUpdate.class);
     } catch (Exception e) {
       return createExceptionResponse(

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -113,6 +113,7 @@ public class DataAccessRequestService implements ConsentLogger {
       InstitutionService institutionService,
       EmailService emailService,
       DACAutomationRuleService ruleService,
+      CountryValidator countryValidator,
       ConsentConfiguration config) {
     this.counterService = counterService;
     this.datasetDAO = jdbi.onDemand(DatasetDAO.class);
@@ -130,7 +131,7 @@ public class DataAccessRequestService implements ConsentLogger {
     this.institutionService = institutionService;
     this.emailService = emailService;
     this.serverUrl = config.getServicesConfiguration().getLocalURL();
-    this.countryValidator = new CountryValidator();
+    this.countryValidator = countryValidator;
   }
 
   public List<DataAccessRequest> findAllDraftDataAccessRequests() {

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -30,12 +30,14 @@ public class MatchService implements ConsentLogger {
 
   @Inject
   public MatchService(
-      Jdbi jdbi, UseRestrictionConverter useRestrictionConverter, OntologyService ontologyService) {
+      Jdbi jdbi,
+      UseRestrictionConverter useRestrictionConverter,
+      DataUseMatcherV4 dataUseMatcherV4) {
     this.matchDAO = jdbi.onDemand(MatchDAO.class);
     this.dataAccessRequestDAO = jdbi.onDemand(DataAccessRequestDAO.class);
     this.useRestrictionConverter = useRestrictionConverter;
     this.datasetDAO = jdbi.onDemand(DatasetDAO.class);
-    this.dataUseMatcherV4 = new DataUseMatcherV4(ontologyService);
+    this.dataUseMatcherV4 = dataUseMatcherV4;
   }
 
   public void insertMatches(List<Match> match) {

--- a/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
@@ -19,6 +19,7 @@ import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.jdbi.v3.core.Jdbi;
 import org.jspecify.annotations.NonNull;
 
 public class OntologyService implements ConsentLogger {
@@ -30,11 +31,11 @@ public class OntologyService implements ConsentLogger {
 
   @Inject
   public OntologyService(
-      OntologyDAO ontologyDAO,
+      Jdbi jdbi,
       OntologyIndexService indexService,
       ExecutorService executorService,
       TranslationUtil translationUtil) {
-    this.ontologyDAO = ontologyDAO;
+    this.ontologyDAO = jdbi.onDemand(OntologyDAO.class);
     this.indexService = indexService;
     this.executorService = executorService;
     this.translationUtil = translationUtil;

--- a/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
@@ -19,7 +19,6 @@ import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.ConsentLogger;
-import org.jdbi.v3.core.Jdbi;
 import org.jspecify.annotations.NonNull;
 
 public class OntologyService implements ConsentLogger {
@@ -31,11 +30,14 @@ public class OntologyService implements ConsentLogger {
 
   @Inject
   public OntologyService(
-      Jdbi jdbi, OntologyIndexService indexService, ExecutorService executorService) {
-    this.ontologyDAO = jdbi.onDemand(OntologyDAO.class);
+      OntologyDAO ontologyDAO,
+      OntologyIndexService indexService,
+      ExecutorService executorService,
+      TranslationUtil translationUtil) {
+    this.ontologyDAO = ontologyDAO;
     this.indexService = indexService;
     this.executorService = executorService;
-    this.translationUtil = new TranslationUtil(this.ontologyDAO);
+    this.translationUtil = translationUtil;
   }
 
   public DataUseSummary translateDataUseSummary(DataUse dataUse) {

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -27,10 +27,11 @@ public class SupportRequestService implements ConsentLogger {
   private final TicketFactory ticketFactory;
 
   @Inject
-  public SupportRequestService(ServicesConfiguration configuration) {
-    this.clientUtil = new HttpClientUtil(configuration);
+  public SupportRequestService(
+      HttpClientUtil clientUtil, TicketFactory ticketFactory, ServicesConfiguration configuration) {
+    this.clientUtil = clientUtil;
     this.configuration = configuration;
-    this.ticketFactory = new TicketFactory();
+    this.ticketFactory = ticketFactory;
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/util/CountryValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/CountryValidator.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -43,6 +44,7 @@ public class CountryValidator {
           "russia",
           "venezuela");
 
+  @Inject
   public CountryValidator() {
     try (InputStream is = getClass().getClassLoader().getResourceAsStream(FILEPATH)) {
       if (is != null) {

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -4,6 +4,7 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import java.util.List;
 import org.apache.commons.validator.routines.DomainValidator;
@@ -14,6 +15,7 @@ public class InstitutionUtil implements ConsentLogger {
 
   private final GsonBuilder gson;
 
+  @Inject
   public InstitutionUtil() {
     this.gson = GsonUtil.gsonBuilderWithAdapters();
   }

--- a/src/main/java/org/broadinstitute/consent/http/util/JsonSchemaUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/JsonSchemaUtil.java
@@ -6,6 +6,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.gson.Gson;
+import com.google.inject.Inject;
 import com.networknt.schema.Error;
 import com.networknt.schema.InputFormat;
 import com.networknt.schema.Schema;
@@ -35,6 +36,7 @@ public class JsonSchemaUtil implements ConsentLogger {
       Map.of("consentGroups", "Datasets");
   private static final String SCHEMA_LOAD_ERROR = "Unable to load the data submitter schema: %s";
 
+  @Inject
   public JsonSchemaUtil() {
     // Create SchemaRegistry with JSON Schema Draft 2019-09
     schemaRegistry =

--- a/src/test/java/org/broadinstitute/consent/http/ConsentModuleTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/ConsentModuleTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jackson.Jackson;
@@ -16,14 +19,87 @@ import jakarta.ws.rs.client.Client;
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import org.broadinstitute.consent.http.authentication.AuthorizationHelper;
+import org.broadinstitute.consent.http.authentication.DuosUserAuthenticator;
+import org.broadinstitute.consent.http.authentication.OAuthAuthenticator;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
+import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
+import org.broadinstitute.consent.http.configurations.MailConfiguration;
+import org.broadinstitute.consent.http.configurations.OidcConfiguration;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.db.DaaDAO;
+import org.broadinstitute.consent.http.db.DarCollectionDAO;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
+import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
+import org.broadinstitute.consent.http.db.DatasetDAO;
+import org.broadinstitute.consent.http.db.DraftDAO;
+import org.broadinstitute.consent.http.db.ElectionDAO;
+import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
+import org.broadinstitute.consent.http.db.LibraryCardDAO;
+import org.broadinstitute.consent.http.db.OidcAuthorityDAO;
+import org.broadinstitute.consent.http.db.SamDAO;
+import org.broadinstitute.consent.http.db.StudyDAO;
+import org.broadinstitute.consent.http.db.UserDAO;
+import org.broadinstitute.consent.http.db.UserRoleDAO;
+import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.filters.ClaimsCache;
+import org.broadinstitute.consent.http.mail.SendGridAPI;
+import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
+import org.broadinstitute.consent.http.matching.DataUseMatcherV4;
+import org.broadinstitute.consent.http.matching.DataUseUtil;
+import org.broadinstitute.consent.http.matching.TranslationUtil;
+import org.broadinstitute.consent.http.models.support.TicketFactory;
+import org.broadinstitute.consent.http.service.AcknowledgementService;
+import org.broadinstitute.consent.http.service.CounterService;
+import org.broadinstitute.consent.http.service.DACAutomationRuleService;
+import org.broadinstitute.consent.http.service.DaaService;
+import org.broadinstitute.consent.http.service.DacService;
+import org.broadinstitute.consent.http.service.DarCollectionService;
+import org.broadinstitute.consent.http.service.DataAccessRequestService;
+import org.broadinstitute.consent.http.service.DatasetRegistrationService;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.ElasticSearchService;
+import org.broadinstitute.consent.http.service.ElectionService;
+import org.broadinstitute.consent.http.service.EmailService;
+import org.broadinstitute.consent.http.service.FeatureFlagService;
+import org.broadinstitute.consent.http.service.FileStorageObjectService;
+import org.broadinstitute.consent.http.service.InstitutionService;
+import org.broadinstitute.consent.http.service.LibraryCardService;
+import org.broadinstitute.consent.http.service.MatchService;
+import org.broadinstitute.consent.http.service.MetricsService;
+import org.broadinstitute.consent.http.service.NihService;
+import org.broadinstitute.consent.http.service.OidcService;
+import org.broadinstitute.consent.http.service.OntologyService;
+import org.broadinstitute.consent.http.service.SupportRequestService;
+import org.broadinstitute.consent.http.service.UseRestrictionConverter;
+import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.VoteService;
+import org.broadinstitute.consent.http.service.dao.DaaServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DacServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DarCollectionServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DraftFileStorageServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DraftServiceDAO;
+import org.broadinstitute.consent.http.service.dao.NihServiceDAO;
+import org.broadinstitute.consent.http.service.dao.UserServiceDAO;
+import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
+import org.broadinstitute.consent.http.service.feature.InstitutionAndLibraryCardEnforcement;
+import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
+import org.broadinstitute.consent.http.service.sam.SamService;
+import org.broadinstitute.consent.http.util.CountryValidator;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.InstitutionUtil;
+import org.broadinstitute.consent.http.util.JsonSchemaUtil;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ConsentModuleTest extends AbstractTestHelper {
 
   private Environment environment;
-  private ConsentModule module;
+  private Injector injector;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -35,133 +111,202 @@ class ConsentModuleTest extends AbstractTestHelper {
                 "dw")
             .build(new File(ResourceHelpers.resourceFilePath("consent-config.yml")));
     environment = new Environment("test");
-    module = new ConsentModule(config, environment);
+    injector = Guice.createInjector(new ConsentModule(config, environment));
   }
 
   @Test
   void testProvidesClient() {
-    assertNotNull(module.providesClient());
-    Client client = module.providesClient();
-    assertSame(client, module.providesClient());
+    Client client = injector.getInstance(Client.class);
+    assertNotNull(client);
+    assertSame(client, injector.getInstance(Client.class));
   }
 
   @Test
   void testProvidesExecutorService() {
-    ExecutorService executorService = module.providesExecutorService();
+    ExecutorService executorService = injector.getInstance(ExecutorService.class);
     assertNotNull(executorService);
     assertFalse(executorService.isShutdown());
-    assertSame(executorService, module.providesExecutorService());
+    assertSame(executorService, injector.getInstance(ExecutorService.class));
   }
 
   @Test
   void testSimpleProvidersSameInstance() {
     // Providers that return pre-built fields or config getters
-    assertSame(module.providesJdbi(), module.providesJdbi());
+    assertSame(injector.getInstance(Jdbi.class), injector.getInstance(Jdbi.class));
     assertSame(
-        module.providesElasticSearchConfiguration(), module.providesElasticSearchConfiguration());
-    assertSame(module.providesMailConfiguration(), module.providesMailConfiguration());
-    assertSame(module.providesServicesConfiguration(), module.providesServicesConfiguration());
-    assertSame(module.providesHealthCheckRegistry(), module.providesHealthCheckRegistry());
-    assertSame(module.providesOidcConfiguration(), module.providesOidcConfiguration());
-    assertSame(module.providesUseRestrictionConverter(), module.providesUseRestrictionConverter());
-    assertSame(module.providesElectionDAO(), module.providesElectionDAO());
-    assertSame(module.providesVoteDAO(), module.providesVoteDAO());
-    assertSame(module.providesStudyDAO(), module.providesStudyDAO());
-    assertSame(module.providesDatasetDAO(), module.providesDatasetDAO());
+        injector.getInstance(ElasticSearchConfiguration.class),
+        injector.getInstance(ElasticSearchConfiguration.class));
     assertSame(
-        module.providesDatasetAuthorizationReaderDAO(),
-        module.providesDatasetAuthorizationReaderDAO());
-    assertSame(module.providesDaaDAO(), module.providesDaaDAO());
-    assertSame(module.providesUserDAO(), module.providesUserDAO());
-    assertSame(module.providesUserRoleDAO(), module.providesUserRoleDAO());
-    assertSame(module.providesFileStorageObjectDAO(), module.providesFileStorageObjectDAO());
-    assertSame(module.providesLibraryCardDAO(), module.providesLibraryCardDAO());
-    assertSame(module.providesDraftDAO(), module.providesDraftDAO());
-    assertSame(module.providesDataAccessRequestDAO(), module.providesDataAccessRequestDAO());
-    assertSame(module.providesDARCollectionDAO(), module.providesDARCollectionDAO());
+        injector.getInstance(MailConfiguration.class),
+        injector.getInstance(MailConfiguration.class));
+    assertSame(
+        injector.getInstance(ServicesConfiguration.class),
+        injector.getInstance(ServicesConfiguration.class));
+    assertSame(
+        injector.getInstance(HealthCheckRegistry.class),
+        injector.getInstance(HealthCheckRegistry.class));
+    assertSame(
+        injector.getInstance(OidcConfiguration.class),
+        injector.getInstance(OidcConfiguration.class));
+    assertSame(
+        injector.getInstance(UseRestrictionConverter.class),
+        injector.getInstance(UseRestrictionConverter.class));
+    assertSame(injector.getInstance(ElectionDAO.class), injector.getInstance(ElectionDAO.class));
+    assertSame(injector.getInstance(VoteDAO.class), injector.getInstance(VoteDAO.class));
+    assertSame(injector.getInstance(StudyDAO.class), injector.getInstance(StudyDAO.class));
+    assertSame(injector.getInstance(DatasetDAO.class), injector.getInstance(DatasetDAO.class));
+    assertSame(
+        injector.getInstance(DatasetAuthorizationReaderDAO.class),
+        injector.getInstance(DatasetAuthorizationReaderDAO.class));
+    assertSame(injector.getInstance(DaaDAO.class), injector.getInstance(DaaDAO.class));
+    assertSame(injector.getInstance(UserDAO.class), injector.getInstance(UserDAO.class));
+    assertSame(injector.getInstance(UserRoleDAO.class), injector.getInstance(UserRoleDAO.class));
+    assertSame(
+        injector.getInstance(FileStorageObjectDAO.class),
+        injector.getInstance(FileStorageObjectDAO.class));
+    assertSame(
+        injector.getInstance(LibraryCardDAO.class), injector.getInstance(LibraryCardDAO.class));
+    assertSame(injector.getInstance(DraftDAO.class), injector.getInstance(DraftDAO.class));
+    assertSame(
+        injector.getInstance(DataAccessRequestDAO.class),
+        injector.getInstance(DataAccessRequestDAO.class));
+    assertSame(
+        injector.getInstance(DarCollectionDAO.class), injector.getInstance(DarCollectionDAO.class));
   }
 
   @Test
   void testMemoizedProvidersReturnTheSameInstance() {
     // Infrastructure and DAO-layer singletons
-    assertSame(module.providesOntologyService(), module.providesOntologyService());
     assertSame(
-        module.providesDatasetRegistrationService(), module.providesDatasetRegistrationService());
+        injector.getInstance(OntologyService.class), injector.getInstance(OntologyService.class));
     assertSame(
-        module.providesInstitutionAndLibraryCardEnforcement(),
-        module.providesInstitutionAndLibraryCardEnforcement());
-    assertSame(module.providesSamDAO(), module.providesSamDAO());
-    assertSame(module.providesHttpClientUtil(), module.providesHttpClientUtil());
-    assertSame(module.providesGCSService(), module.providesGCSService());
-    assertSame(module.providesOntologyIndexService(), module.providesOntologyIndexService());
-    assertSame(module.providesElasticSearchService(), module.providesElasticSearchService());
-    assertSame(module.providesDatasetServiceDAO(), module.providesDatasetServiceDAO());
-    assertSame(module.providesDarCollectionServiceDAO(), module.providesDarCollectionServiceDAO());
+        injector.getInstance(DatasetRegistrationService.class),
+        injector.getInstance(DatasetRegistrationService.class));
     assertSame(
-        module.providesDataAccessRequestServiceDAO(), module.providesDataAccessRequestServiceDAO());
-    assertSame(module.providesVoteServiceDAO(), module.providesVoteServiceDAO());
-    assertSame(module.providesDaaServiceDAO(), module.providesDaaServiceDAO());
-    assertSame(module.providesDacServiceDAO(), module.providesDacServiceDAO());
-    assertSame(module.providesNIHServiceDAO(), module.providesNIHServiceDAO());
-    assertSame(module.providesUserServiceDAO(), module.providesUserServiceDAO());
-    assertSame(module.providesElectionService(), module.providesElectionService());
-    assertSame(module.providesFeatureFlagService(), module.providesFeatureFlagService());
-    assertSame(module.providesMetricsService(), module.providesMetricsService());
-    assertSame(module.providesSamService(), module.providesSamService());
-    assertSame(module.providesOidcAuthorityDAO(), module.providesOidcAuthorityDAO());
-    assertSame(module.providesOidcService(), module.providesOidcService());
-    assertSame(module.providesSupportRequestService(), module.providesSupportRequestService());
+        injector.getInstance(InstitutionAndLibraryCardEnforcement.class),
+        injector.getInstance(InstitutionAndLibraryCardEnforcement.class));
+    assertSame(injector.getInstance(SamDAO.class), injector.getInstance(SamDAO.class));
+    assertSame(
+        injector.getInstance(HttpClientUtil.class), injector.getInstance(HttpClientUtil.class));
+    assertSame(injector.getInstance(GCSService.class), injector.getInstance(GCSService.class));
+    assertSame(
+        injector.getInstance(OntologyIndexService.class),
+        injector.getInstance(OntologyIndexService.class));
+    assertSame(
+        injector.getInstance(ElasticSearchService.class),
+        injector.getInstance(ElasticSearchService.class));
+    assertSame(
+        injector.getInstance(DatasetServiceDAO.class),
+        injector.getInstance(DatasetServiceDAO.class));
+    assertSame(
+        injector.getInstance(DarCollectionServiceDAO.class),
+        injector.getInstance(DarCollectionServiceDAO.class));
+    assertSame(
+        injector.getInstance(DataAccessRequestServiceDAO.class),
+        injector.getInstance(DataAccessRequestServiceDAO.class));
+    assertSame(
+        injector.getInstance(VoteServiceDAO.class), injector.getInstance(VoteServiceDAO.class));
+    assertSame(
+        injector.getInstance(DaaServiceDAO.class), injector.getInstance(DaaServiceDAO.class));
+    assertSame(
+        injector.getInstance(DacServiceDAO.class), injector.getInstance(DacServiceDAO.class));
+    assertSame(
+        injector.getInstance(NihServiceDAO.class), injector.getInstance(NihServiceDAO.class));
+    assertSame(
+        injector.getInstance(UserServiceDAO.class), injector.getInstance(UserServiceDAO.class));
+    assertSame(
+        injector.getInstance(ElectionService.class), injector.getInstance(ElectionService.class));
+    assertSame(
+        injector.getInstance(FeatureFlagService.class),
+        injector.getInstance(FeatureFlagService.class));
+    assertSame(
+        injector.getInstance(MetricsService.class), injector.getInstance(MetricsService.class));
+    assertSame(injector.getInstance(SamService.class), injector.getInstance(SamService.class));
+    assertSame(
+        injector.getInstance(OidcAuthorityDAO.class), injector.getInstance(OidcAuthorityDAO.class));
+    assertSame(injector.getInstance(OidcService.class), injector.getInstance(OidcService.class));
+    assertSame(
+        injector.getInstance(SupportRequestService.class),
+        injector.getInstance(SupportRequestService.class));
   }
 
   @Test
   void testMemoizedServiceProvidersReturnTheSameInstance() {
     // Business service singletons
     assertSame(
-        module.providesFreeMarkerTemplateHelper(), module.providesFreeMarkerTemplateHelper());
-    assertSame(module.providesEmailService(), module.providesEmailService());
-    assertSame(module.providesSendGridAPI(), module.providesSendGridAPI());
-    assertSame(module.providesCounterService(), module.providesCounterService());
-    assertSame(module.providesRuleService(), module.providesRuleService());
-    assertSame(module.providesVoteService(), module.providesVoteService());
-    assertSame(module.providesMatchService(), module.providesMatchService());
-    assertSame(module.providesInstitutionService(), module.providesInstitutionService());
-    assertSame(module.providesLibraryCardService(), module.providesLibraryCardService());
-    assertSame(module.providesUserService(), module.providesUserService());
-    assertSame(module.providesDatasetService(), module.providesDatasetService());
-    assertSame(module.providesDaaService(), module.providesDaaService());
-    assertSame(module.providesDacService(), module.providesDacService());
-    assertSame(module.providesAcknowledgementService(), module.providesAcknowledgementService());
-    assertSame(module.providesNihService(), module.providesNihService());
+        injector.getInstance(FreeMarkerTemplateHelper.class),
+        injector.getInstance(FreeMarkerTemplateHelper.class));
+    assertSame(injector.getInstance(EmailService.class), injector.getInstance(EmailService.class));
+    assertSame(injector.getInstance(SendGridAPI.class), injector.getInstance(SendGridAPI.class));
     assertSame(
-        module.providesDataAccessRequestService(), module.providesDataAccessRequestService());
+        injector.getInstance(CounterService.class), injector.getInstance(CounterService.class));
     assertSame(
-        module.providesFileStorageObjectService(), module.providesFileStorageObjectService());
-    assertSame(module.providesDarCollectionService(), module.providesDarCollectionService());
-    assertSame(module.providesDraftFileStorageService(), module.providesDraftFileStorageService());
-    assertSame(module.providesDraftServiceDAO(), module.providesDraftServiceDAO());
-    assertSame(module.providesAuthorizationHelper(), module.providesAuthorizationHelper());
-    assertSame(module.providesOAuthAuthenticator(), module.providesOAuthAuthenticator());
+        injector.getInstance(DACAutomationRuleService.class),
+        injector.getInstance(DACAutomationRuleService.class));
+    assertSame(injector.getInstance(VoteService.class), injector.getInstance(VoteService.class));
+    assertSame(injector.getInstance(MatchService.class), injector.getInstance(MatchService.class));
     assertSame(
-        module.providesDuosUserOAuthAuthenticator(), module.providesDuosUserOAuthAuthenticator());
+        injector.getInstance(InstitutionService.class),
+        injector.getInstance(InstitutionService.class));
+    assertSame(
+        injector.getInstance(LibraryCardService.class),
+        injector.getInstance(LibraryCardService.class));
+    assertSame(injector.getInstance(UserService.class), injector.getInstance(UserService.class));
+    assertSame(
+        injector.getInstance(DatasetService.class), injector.getInstance(DatasetService.class));
+    assertSame(injector.getInstance(DaaService.class), injector.getInstance(DaaService.class));
+    assertSame(injector.getInstance(DacService.class), injector.getInstance(DacService.class));
+    assertSame(
+        injector.getInstance(AcknowledgementService.class),
+        injector.getInstance(AcknowledgementService.class));
+    assertSame(injector.getInstance(NihService.class), injector.getInstance(NihService.class));
+    assertSame(
+        injector.getInstance(DataAccessRequestService.class),
+        injector.getInstance(DataAccessRequestService.class));
+    assertSame(
+        injector.getInstance(FileStorageObjectService.class),
+        injector.getInstance(FileStorageObjectService.class));
+    assertSame(
+        injector.getInstance(DarCollectionService.class),
+        injector.getInstance(DarCollectionService.class));
+    assertSame(
+        injector.getInstance(DraftFileStorageServiceDAO.class),
+        injector.getInstance(DraftFileStorageServiceDAO.class));
+    assertSame(
+        injector.getInstance(DraftServiceDAO.class), injector.getInstance(DraftServiceDAO.class));
+    assertSame(
+        injector.getInstance(AuthorizationHelper.class),
+        injector.getInstance(AuthorizationHelper.class));
+    assertSame(
+        injector.getInstance(OAuthAuthenticator.class),
+        injector.getInstance(OAuthAuthenticator.class));
+    assertSame(
+        injector.getInstance(DuosUserAuthenticator.class),
+        injector.getInstance(DuosUserAuthenticator.class));
   }
 
   @Test
   void testNewSingletonProvidersReturnTheSameInstance() {
     // New providers added for injectable DI pattern
-    assertSame(module.providesOntologyDAO(), module.providesOntologyDAO());
-    assertSame(module.providesClaimsCache(), module.providesClaimsCache());
-    assertSame(module.providesTranslationUtil(), module.providesTranslationUtil());
-    assertSame(module.providesDataUseUtil(), module.providesDataUseUtil());
-    assertSame(module.providesDataUseMatcherV4(), module.providesDataUseMatcherV4());
-    assertSame(module.providesCountryValidator(), module.providesCountryValidator());
-    assertSame(module.providesInstitutionUtil(), module.providesInstitutionUtil());
-    assertSame(module.providesJsonSchemaUtil(), module.providesJsonSchemaUtil());
-    assertSame(module.providesTicketFactory(), module.providesTicketFactory());
+    assertSame(injector.getInstance(ClaimsCache.class), injector.getInstance(ClaimsCache.class));
+    assertSame(
+        injector.getInstance(TranslationUtil.class), injector.getInstance(TranslationUtil.class));
+    assertSame(injector.getInstance(DataUseUtil.class), injector.getInstance(DataUseUtil.class));
+    assertSame(
+        injector.getInstance(DataUseMatcherV4.class), injector.getInstance(DataUseMatcherV4.class));
+    assertSame(
+        injector.getInstance(CountryValidator.class), injector.getInstance(CountryValidator.class));
+    assertSame(
+        injector.getInstance(InstitutionUtil.class), injector.getInstance(InstitutionUtil.class));
+    assertSame(
+        injector.getInstance(JsonSchemaUtil.class), injector.getInstance(JsonSchemaUtil.class));
+    assertSame(
+        injector.getInstance(TicketFactory.class), injector.getInstance(TicketFactory.class));
   }
 
   @Test
   void testExecutorServiceShutsDownOnLifecycleStop() throws Exception {
-    try (ExecutorService executorService = module.providesExecutorService()) {
+    try (ExecutorService executorService = injector.getInstance(ExecutorService.class)) {
       assertFalse(executorService.isShutdown());
       findExecutorManaged().stop();
       assertTrue(executorService.isTerminated());
@@ -170,7 +315,7 @@ class ConsentModuleTest extends AbstractTestHelper {
 
   @Test
   void testExecutorServiceShutdownNowWhenStopIsInterrupted() throws Exception {
-    try (ExecutorService executorService = module.providesExecutorService()) {
+    try (ExecutorService executorService = injector.getInstance(ExecutorService.class)) {
       // Keep a task in flight so the executor is not yet terminated when stop() awaits it.
       CountDownLatch taskRunning = new CountDownLatch(1);
       executorService.submit(

--- a/src/test/java/org/broadinstitute/consent/http/ConsentModuleTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/ConsentModuleTest.java
@@ -54,6 +54,34 @@ class ConsentModuleTest extends AbstractTestHelper {
   }
 
   @Test
+  void testSimpleProvidersSameInstance() {
+    // Providers that return pre-built fields or config getters
+    assertSame(module.providesJdbi(), module.providesJdbi());
+    assertSame(
+        module.providesElasticSearchConfiguration(), module.providesElasticSearchConfiguration());
+    assertSame(module.providesMailConfiguration(), module.providesMailConfiguration());
+    assertSame(module.providesServicesConfiguration(), module.providesServicesConfiguration());
+    assertSame(module.providesHealthCheckRegistry(), module.providesHealthCheckRegistry());
+    assertSame(module.providesOidcConfiguration(), module.providesOidcConfiguration());
+    assertSame(module.providesUseRestrictionConverter(), module.providesUseRestrictionConverter());
+    assertSame(module.providesElectionDAO(), module.providesElectionDAO());
+    assertSame(module.providesVoteDAO(), module.providesVoteDAO());
+    assertSame(module.providesStudyDAO(), module.providesStudyDAO());
+    assertSame(module.providesDatasetDAO(), module.providesDatasetDAO());
+    assertSame(
+        module.providesDatasetAuthorizationReaderDAO(),
+        module.providesDatasetAuthorizationReaderDAO());
+    assertSame(module.providesDaaDAO(), module.providesDaaDAO());
+    assertSame(module.providesUserDAO(), module.providesUserDAO());
+    assertSame(module.providesUserRoleDAO(), module.providesUserRoleDAO());
+    assertSame(module.providesFileStorageObjectDAO(), module.providesFileStorageObjectDAO());
+    assertSame(module.providesLibraryCardDAO(), module.providesLibraryCardDAO());
+    assertSame(module.providesDraftDAO(), module.providesDraftDAO());
+    assertSame(module.providesDataAccessRequestDAO(), module.providesDataAccessRequestDAO());
+    assertSame(module.providesDARCollectionDAO(), module.providesDARCollectionDAO());
+  }
+
+  @Test
   void testMemoizedProvidersReturnTheSameInstance() {
     // Infrastructure and DAO-layer singletons
     assertSame(module.providesOntologyService(), module.providesOntologyService());
@@ -111,6 +139,24 @@ class ConsentModuleTest extends AbstractTestHelper {
     assertSame(module.providesDarCollectionService(), module.providesDarCollectionService());
     assertSame(module.providesDraftFileStorageService(), module.providesDraftFileStorageService());
     assertSame(module.providesDraftServiceDAO(), module.providesDraftServiceDAO());
+    assertSame(module.providesAuthorizationHelper(), module.providesAuthorizationHelper());
+    assertSame(module.providesOAuthAuthenticator(), module.providesOAuthAuthenticator());
+    assertSame(
+        module.providesDuosUserOAuthAuthenticator(), module.providesDuosUserOAuthAuthenticator());
+  }
+
+  @Test
+  void testNewSingletonProvidersReturnTheSameInstance() {
+    // New providers added for injectable DI pattern
+    assertSame(module.providesOntologyDAO(), module.providesOntologyDAO());
+    assertSame(module.providesClaimsCache(), module.providesClaimsCache());
+    assertSame(module.providesTranslationUtil(), module.providesTranslationUtil());
+    assertSame(module.providesDataUseUtil(), module.providesDataUseUtil());
+    assertSame(module.providesDataUseMatcherV4(), module.providesDataUseMatcherV4());
+    assertSame(module.providesCountryValidator(), module.providesCountryValidator());
+    assertSame(module.providesInstitutionUtil(), module.providesInstitutionUtil());
+    assertSame(module.providesJsonSchemaUtil(), module.providesJsonSchemaUtil());
+    assertSame(module.providesTicketFactory(), module.providesTicketFactory());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
@@ -53,13 +53,13 @@ class AuthorizationHelperTest extends AbstractTestHelper {
   private AuthorizationHelper authorizationHelper;
   private DuosUserAuthenticator duosUserAuthenticator;
   private OAuthAuthenticator oAuthAuthenticator;
-  private final ClaimsCache headerCache = ClaimsCache.getInstance();
+  private final ClaimsCache headerCache = new ClaimsCache();
   private final String bearerToken = randomAlphabetic(100);
   private final MultivaluedMap<String, String> headerMap = new MultivaluedHashMap<>();
 
   @BeforeEach
   void setUp() {
-    authorizationHelper = new AuthorizationHelper(samService, userService);
+    authorizationHelper = new AuthorizationHelper(samService, userService, headerCache);
     headerCache.cache.invalidateAll();
     duosUserAuthenticator = new DuosUserAuthenticator(authorizationHelper);
     oAuthAuthenticator = new OAuthAuthenticator(authorizationHelper);

--- a/src/test/java/org/broadinstitute/consent/http/filters/ClaimsCacheTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/filters/ClaimsCacheTest.java
@@ -1,0 +1,94 @@
+package org.broadinstitute.consent.http.filters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.AbstractMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClaimsCacheTest {
+
+  @Mock private MultivaluedMap<String, String> mockHeaders;
+
+  private ClaimsCache claimsCache;
+
+  @BeforeEach
+  void setUp() {
+    claimsCache = new ClaimsCache();
+  }
+
+  @Test
+  void testConstructorInitializesCache() {
+    assertNotNull(claimsCache.cache);
+  }
+
+  @Test
+  void testLoadCacheAddsTokenToCache() {
+    MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+    headers.add(ClaimsCache.OAUTH2_CLAIM_email, "test@example.com");
+    headers.add(ClaimsCache.OAUTH2_CLAIM_name, "Test User");
+
+    claimsCache.loadCache("test-token", headers);
+
+    Map<String, String> cached = claimsCache.cache.getIfPresent("test-token");
+    assertNotNull(cached);
+    assertEquals("test@example.com", cached.get(ClaimsCache.OAUTH2_CLAIM_email));
+    assertEquals("Test User", cached.get(ClaimsCache.OAUTH2_CLAIM_name));
+  }
+
+  @Test
+  void testLoadCacheDoesNotOverwriteExistingToken() {
+    MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+    headers.add(ClaimsCache.OAUTH2_CLAIM_email, "first@example.com");
+    claimsCache.loadCache("test-token", headers);
+
+    MultivaluedHashMap<String, String> headers2 = new MultivaluedHashMap<>();
+    headers2.add(ClaimsCache.OAUTH2_CLAIM_email, "second@example.com");
+    claimsCache.loadCache("test-token", headers2);
+
+    assertEquals(
+        "first@example.com",
+        claimsCache.cache.getIfPresent("test-token").get(ClaimsCache.OAUTH2_CLAIM_email));
+  }
+
+  @Test
+  void testLoadCacheFiltersNonOauthHeaders() {
+    MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+    headers.add("Authorization", "Bearer token");
+    headers.add(ClaimsCache.OAUTH2_CLAIM_email, "test@example.com");
+
+    claimsCache.loadCache("test-token", headers);
+
+    Map<String, String> cached = claimsCache.cache.getIfPresent("test-token");
+    assertNotNull(cached);
+    assertFalse(cached.containsKey("Authorization"));
+    assertTrue(cached.containsKey(ClaimsCache.OAUTH2_CLAIM_email));
+  }
+
+  @Test
+  void testLoadCacheWithNullHeaderValueListThrows() {
+    // A null value list reaches the null branch in getFirst(), but Collectors.toMap
+    // does not support null values, so NPE is thrown before the entry is stored.
+    Set<Map.Entry<String, List<String>>> entries = new HashSet<>();
+    entries.add(new AbstractMap.SimpleEntry<>(ClaimsCache.OAUTH2_CLAIM_email, null));
+    when(mockHeaders.entrySet()).thenReturn(entries);
+
+    assertThrows(
+        NullPointerException.class, () -> claimsCache.loadCache("test-token", mockHeaders));
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilterTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.filters;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,7 +35,7 @@ class RequestHeaderCacheFilterTest {
 
     filter.filter(requestContext);
 
-    verify(claimsCache).loadCache(eq("test-token"), eq(headers));
+    verify(claimsCache).loadCache("test-token", headers);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilterTest.java
@@ -1,0 +1,48 @@
+package org.broadinstitute.consent.http.filters;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RequestHeaderCacheFilterTest {
+
+  @Mock private ClaimsCache claimsCache;
+  @Mock private ContainerRequestContext requestContext;
+  @Mock private MultivaluedMap<String, String> headers;
+
+  private RequestHeaderCacheFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    filter = new RequestHeaderCacheFilter(claimsCache);
+    when(requestContext.getHeaders()).thenReturn(headers);
+  }
+
+  @Test
+  void testFilterCallsLoadCacheWhenTokenPresent() throws Exception {
+    when(headers.getFirst(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer test-token");
+
+    filter.filter(requestContext);
+
+    verify(claimsCache).loadCache(eq("test-token"), eq(headers));
+  }
+
+  @Test
+  void testFilterDoesNotCallLoadCacheWhenNoAuthorizationHeader() throws Exception {
+    filter.filter(requestContext);
+
+    verify(claimsCache, never()).loadCache(any(), any());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4Test.java
@@ -101,7 +101,7 @@ class DataUseMatcherV4Test {
 
   @Test
   void testMatchPurposeAndDatasetV4Failure() {
-    DataUseMatcherV4 matcher = new DataUseMatcherV4(ontologyService);
+    DataUseMatcherV4 matcher = new DataUseMatcherV4(new DataUseUtil(ontologyService));
 
     MatchResult result = matcher.matchPurposeAndDatasetV4(null, null);
     assertEquals(DataUseMatchResultType.DENY, result.getMatchResultType());
@@ -347,7 +347,7 @@ class DataUseMatcherV4Test {
   }
 
   private MatchResult matchPurposeAndDataset(DataUse purpose, DataUse dataset) {
-    DataUseMatcherV4 matcher = new DataUseMatcherV4(ontologyService);
+    DataUseMatcherV4 matcher = new DataUseMatcherV4(new DataUseUtil(ontologyService));
     return matcher.matchPurposeAndDatasetV4(purpose, dataset);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -19,6 +19,7 @@ import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,11 +34,13 @@ class TranslationUtilTest extends AbstractTestHelper {
   private TranslationUtil service;
   private final Gson gson = GsonUtil.getInstance();
 
+  @Mock private Jdbi jdbi;
   @Mock private OntologyDAO ontologyDAO;
 
   @BeforeEach
   void setUpClass() {
-    service = new TranslationUtil(ontologyDAO);
+    when(jdbi.onDemand(OntologyDAO.class)).thenReturn(ontologyDAO);
+    service = new TranslationUtil(jdbi);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -68,6 +68,7 @@ import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
 import org.broadinstitute.consent.http.service.TDRService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.util.JsonSchemaUtil;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -108,7 +109,8 @@ class DatasetResourceTest extends AbstractTestHelper {
             datasetRegistrationService,
             elasticSearchService,
             tdrService,
-            gcsService);
+            gcsService,
+            new JsonSchemaUtil());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -24,6 +24,7 @@ import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.InstitutionService;
+import org.broadinstitute.consent.http.util.InstitutionUtil;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ class InstitutionResourceTest {
 
   @BeforeEach
   void initResource() {
-    resource = new InstitutionResource(institutionService);
+    resource = new InstitutionResource(institutionService, new InstitutionUtil());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/SchemaResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/SchemaResourceTest.java
@@ -16,7 +16,7 @@ class SchemaResourceTest {
 
   @Test
   void testGetDatasetRegistrationSchemaV1() {
-    SchemaResource resource = new SchemaResource();
+    SchemaResource resource = new SchemaResource(jsonSchemaUtil);
 
     Response response = resource.getDatasetRegistrationSchemaV1();
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -76,6 +76,7 @@ import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
 import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
+import org.broadinstitute.consent.http.util.CountryValidator;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
@@ -184,6 +185,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
             institutionService,
             emailService,
             ruleService,
+            new CountryValidator(),
             config);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -22,6 +22,8 @@ import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
+import org.broadinstitute.consent.http.matching.DataUseMatcherV4;
+import org.broadinstitute.consent.http.matching.DataUseUtil;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
@@ -44,6 +46,7 @@ class MatchServiceTest extends AbstractTestHelper {
   @Mock private UseRestrictionConverter useRestrictionConverter;
   @Mock private OntologyService ontologyService;
 
+  private DataUseMatcherV4 dataUseMatcherV4;
   private MatchService service;
 
   @BeforeEach
@@ -51,7 +54,8 @@ class MatchServiceTest extends AbstractTestHelper {
     when(jdbi.onDemand(MatchDAO.class)).thenReturn(matchDAO);
     when(jdbi.onDemand(DataAccessRequestDAO.class)).thenReturn(dataAccessRequestDAO);
     when(jdbi.onDemand(DatasetDAO.class)).thenReturn(datasetDAO);
-    service = new MatchService(jdbi, useRestrictionConverter, ontologyService);
+    dataUseMatcherV4 = new DataUseMatcherV4(new DataUseUtil(ontologyService));
+    service = new MatchService(jdbi, useRestrictionConverter, dataUseMatcherV4);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -75,7 +75,7 @@ class OntologyServiceTest extends AbstractTestHelper {
     // so tests can assert on their effects without sleeps or teardown races.
     executorService = MoreExecutors.newDirectExecutorService();
     when(jdbi.onDemand(OntologyDAO.class)).thenReturn(ontologyDAO);
-    translationUtil = new TranslationUtil(ontologyDAO);
+    translationUtil = new TranslationUtil(jdbi);
     service = new OntologyService(jdbi, indexService, executorService, translationUtil);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -38,7 +38,6 @@ import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.TestAppender;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,8 +55,8 @@ class OntologyServiceTest extends AbstractTestHelper {
   private OntologyService service;
   private ExecutorService executorService;
   private TestAppender testAppender;
+  private TranslationUtil translationUtil;
   private final Gson gson = GsonUtil.getInstance();
-  @Mock private Jdbi jdbi;
   @Mock private OntologyDAO ontologyDAO;
   @Mock private OntologyIndexService indexService;
 
@@ -73,8 +72,8 @@ class OntologyServiceTest extends AbstractTestHelper {
     // A same-thread executor makes indexOntology's async task and callback run synchronously,
     // so tests can assert on their effects without sleeps or teardown races.
     executorService = MoreExecutors.newDirectExecutorService();
-    when(jdbi.onDemand(OntologyDAO.class)).thenReturn(ontologyDAO);
-    service = new OntologyService(jdbi, indexService, executorService);
+    translationUtil = new TranslationUtil(ontologyDAO);
+    service = new OntologyService(ontologyDAO, indexService, executorService, translationUtil);
   }
 
   @AfterEach

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -38,6 +38,7 @@ import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.TestAppender;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,7 @@ class OntologyServiceTest extends AbstractTestHelper {
   private TestAppender testAppender;
   private TranslationUtil translationUtil;
   private final Gson gson = GsonUtil.getInstance();
+  @Mock private Jdbi jdbi;
   @Mock private OntologyDAO ontologyDAO;
   @Mock private OntologyIndexService indexService;
 
@@ -72,8 +74,9 @@ class OntologyServiceTest extends AbstractTestHelper {
     // A same-thread executor makes indexOntology's async task and callback run synchronously,
     // so tests can assert on their effects without sleeps or teardown races.
     executorService = MoreExecutors.newDirectExecutorService();
+    when(jdbi.onDemand(OntologyDAO.class)).thenReturn(ontologyDAO);
     translationUtil = new TranslationUtil(ontologyDAO);
-    service = new OntologyService(ontologyDAO, indexService, executorService, translationUtil);
+    service = new OntologyService(jdbi, indexService, executorService, translationUtil);
   }
 
   @AfterEach

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.consent.http.enumeration.SupportRequestType;
 import org.broadinstitute.consent.http.models.support.DuosTicket;
 import org.broadinstitute.consent.http.models.support.TicketFactory;
 import org.broadinstitute.consent.http.models.support.TicketFields;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ class SupportRequestServiceIntegrationTest {
   void setUp() {
     ServicesConfiguration config = new ServicesConfiguration();
     config.setActivateSupportNotifications(true);
-    service = new SupportRequestService(config);
+    service = new SupportRequestService(new HttpClientUtil(config), new TicketFactory(), config);
   }
 
   @Disabled

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -28,6 +28,7 @@ import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
 import org.broadinstitute.consent.http.models.support.DuosTicket;
 import org.broadinstitute.consent.http.models.support.TicketFactory;
 import org.broadinstitute.consent.http.models.support.TicketFields;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +43,7 @@ class SupportRequestServiceTest extends WireMockTestHelper {
 
   @BeforeEach
   void init() {
-    service = new SupportRequestService(config);
+    service = new SupportRequestService(new HttpClientUtil(config), new TicketFactory(), config);
   }
 
   @Test
@@ -122,7 +123,7 @@ class SupportRequestServiceTest extends WireMockTestHelper {
                     .withHeader("Content-Type", "application/json")
                     .withStatus(HttpStatusCodes.STATUS_CODE_CREATED)
                     .withBody(expectedBody)));
-    service = new SupportRequestService(config);
+    service = new SupportRequestService(new HttpClientUtil(config), new TicketFactory(), config);
     service.postAttachmentToSupport("Test".getBytes());
     URL supportUrl = URI.create(config.postSupportUploadUrl()).toURL();
     wireMockServer.verify(exactly(1), postRequestedFor(urlPathEqualTo(supportUrl.getPath())));

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -1626,7 +1626,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = userDAO.findUserById(dataset.getCreateUserId());
     DataUse newDataUse = new DataUseBuilder().setGeneralUse(true).setHmbResearch(true).build();
     String translatedDataUse =
-        new TranslationUtil(ontologyDAO).translate(newDataUse, DataUseTranslationType.DATASET);
+        new TranslationUtil(jdbi).translate(newDataUse, DataUseTranslationType.DATASET);
     serviceDAO.updateDatasetDataUse(user, dataset, newDataUse, translatedDataUse);
     Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(translatedDataUse, updatedDataset.getTranslatedDataUse());

--- a/src/test/java/org/broadinstitute/consent/integration/ContainerTests.java
+++ b/src/test/java/org/broadinstitute/consent/integration/ContainerTests.java
@@ -10,6 +10,7 @@ import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import jakarta.ws.rs.client.Client;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -51,6 +52,7 @@ public abstract class ContainerTests implements ConsentLogger {
   private static final PostgreSQLContainer<?> POSTGRES =
       new PostgreSQLContainer<>(DAOTestHelper.POSTGRES_IMAGE)
           .withCommand("postgres -c max_connections=20")
+          .withTmpFs(Collections.singletonMap("/var/lib/postgresql/data", "rw"))
           .waitingFor(Wait.forListeningPorts());
 
   static {

--- a/src/test/java/org/broadinstitute/consent/integration/ContainerTests.java
+++ b/src/test/java/org/broadinstitute/consent/integration/ContainerTests.java
@@ -10,7 +10,6 @@ import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import jakarta.ws.rs.client.Client;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -52,7 +51,6 @@ public abstract class ContainerTests implements ConsentLogger {
   private static final PostgreSQLContainer<?> POSTGRES =
       new PostgreSQLContainer<>(DAOTestHelper.POSTGRES_IMAGE)
           .withCommand("postgres -c max_connections=20")
-          .withTmpFs(Collections.singletonMap("/var/lib/postgresql/data", "rw"))
           .waitingFor(Wait.forListeningPorts());
 
   static {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3601](https://broadworkbench.atlassian.net/browse/DT-3601)

### Summary


`ConsentModule` contained a mix of scoped and unscoped providers. Several providers were annotated `@Singleton` but bypassed Guice's scoping by calling sibling provider methods directly rather than through the injector — meaning a second call to a provider method would construct a second object even though the method carried `@Singleton`. Other providers constructed managed objects (`ClaimsCache`, `HttpClientUtil`, `DataUseMatcherV4`, etc.) with `new` inside downstream service constructors, producing unmanaged instances outside Guice's lifecycle entirely.

---

### Changes

#### `ConsentModule` — provider consistency

All providers that were missing `@Singleton` now have it. The four config-getter providers (`providesElasticSearchConfiguration`, `providesMailConfiguration`, `providesServicesConfiguration`, `providesOidcConfiguration`) gain `synchronized` null-check memoization fields to close the scoping gap that exists when `@Provides @Singleton` methods call each other as plain Java methods.

Nine new singleton providers are added for previously-unmanaged leaf types:

| New provider | Type |
|---|---|
| `providesOntologyDAO()` | `OntologyDAO` |
| `providesClaimsCache()` | `ClaimsCache` |
| `providesTranslationUtil()` | `TranslationUtil` |
| `providesDataUseUtil()` | `DataUseUtil` |
| `providesDataUseMatcherV4()` | `DataUseMatcherV4` |
| `providesCountryValidator()` | `CountryValidator` |
| `providesInstitutionUtil()` | `InstitutionUtil` |
| `providesJsonSchemaUtil()` | `JsonSchemaUtil` |
| `providesTicketFactory()` | `TicketFactory` |

Existing providers that were constructing those types with `new` are updated to receive them as injected parameters.

#### `ClaimsCache` — static singleton removed

`ClaimsCache` previously held a static `INSTANCE` field with no `volatile` and no synchronization — a race-prone pattern. The static field and `getInstance()` are removed; the constructor is changed from `private` to `@Inject public`, making `ClaimsCache` a proper Guice-managed singleton.

#### `RequestHeaderCacheFilter` — constructor injection + registration fix

The filter was acquiring its `ClaimsCache` via the (now-deleted) `ClaimsCache.getInstance()` field initializer. It now receives `ClaimsCache` through an `@Inject` constructor.

The registration in `ConsentApplication` is updated from:

```java
env.jersey().register(RequestHeaderCacheFilter.class);
```

to:

```java
env.jersey().register(injector.getInstance(RequestHeaderCacheFilter.class));
```

Registering by class let Jersey/HK2 create its own unmanaged instance, which would have been a different `ClaimsCache` object from the one used by the auth pipeline. Registering the Guice instance ensures the filter and all auth components share the same singleton.

#### Service and resource constructors — stop using `new`

| Class | Before | After |
|---|---|---|
| `OntologyService` | `new TranslationUtil(jdbi.onDemand(...))` | `TranslationUtil` injected |
| `DataUseMatcherV4` | `new DataUseUtil(ontologyService)` | `DataUseUtil` injected |
| `MatchService` | `new DataUseMatcherV4(ontologyService)` | `DataUseMatcherV4` injected |
| `DataAccessRequestService` | `new CountryValidator()` | `CountryValidator` injected |
| `SupportRequestService` | `new HttpClientUtil(config)`, `new TicketFactory()` | both injected |
| `DatasetResource` | `new JsonSchemaUtil()` | `JsonSchemaUtil` injected |
| `SchemaResource` | `new JsonSchemaUtil()` | `JsonSchemaUtil` injected |
| `InstitutionResource` | `new InstitutionUtil()` | `InstitutionUtil` injected |
| `AuthorizationHelper` | `ClaimsCache.getInstance()` | `ClaimsCache` injected |

#### Leaf classes — `@Inject` annotations

`DataUseUtil`, `TranslationUtil`, `CountryValidator`, `InstitutionUtil`, `JsonSchemaUtil`, and `TicketFactory` each gain `@Inject` on their existing constructors so Guice can construct and wire them.

#### Gson — deferred TODO comments - see [https://broadworkbench.atlassian.net/browse/DT-3689](https://broadworkbench.atlassian.net/browse/DT-3689) for follow-on work.

`VoteResource`, `DaaResource`, `StudyResource`, `DatasetResource`, `SamHealthCheck`, and `SendGridHealthCheck` contain `new Gson()` calls. Switching to `GsonUtil.buildGson()` requires further investigation of Gson configuration options; each site is annotated with a TODO rather than changed:

```java
// TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson configuration investigation
```

---

### Tests

- **`ConsentModuleTest`** — new `testNewSingletonProvidersReturnTheSameInstance` asserts `assertSame` across all nine new providers; updates the four existing config-getter singleton assertions.
- **`ClaimsCacheTest`** _(new)_ — covers constructor initialisation, cache population, no-overwrite on repeat token, non-OAuth header filtering, and the null-value-list branch (documents that `Collectors.toMap` throws `NullPointerException` for null header value lists).
- **`RequestHeaderCacheFilterTest`** _(new)_ — covers the token-present path (verifies `loadCache` is called with the stripped bearer value) and the no-token path (verifies `loadCache` is never called).
- All existing tests that construct the modified services and resources are updated to supply the now-required injected parameters directly.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
