### PR TITLE
[DT-3690] Apply ClaimsCache and RequestHeaderCacheFilter feedback adjustments

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/filters/ClaimsCache.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/ClaimsCache.java
@@ -4,8 +4,6 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
-import java.util.AbstractMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
@@ -28,22 +26,17 @@ public class ClaimsCache {
     cache = CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
   }
 
-  private String getFirst(List<String> headerValues) {
-    if (headerValues == null) {
-      return null;
-    }
-    return headerValues.stream().findFirst().orElse(null);
-  }
-
   public void loadCache(String token, MultivaluedMap<String, String> headers) {
-    if (this.cache.getIfPresent(token) == null) {
-      Map<String, String> claimsMap =
-          headers.entrySet().stream()
-              .filter(e -> e.getKey().startsWith("OAUTH2_CLAIM"))
-              .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), getFirst(e.getValue())))
-              .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-      this.cache.put(token, claimsMap);
-      this.cache.cleanUp();
+    try {
+      this.cache.get(
+          token,
+          () ->
+              headers.entrySet().stream()
+                  .filter(e -> e.getKey().startsWith("OAUTH2_CLAIM"))
+                  .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+                  .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().get(0))));
+    } catch (Exception _) {
+      // header map is caller-supplied; a failure here means no cache entry is stored
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilter.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilter.java
@@ -24,7 +24,7 @@ public class RequestHeaderCacheFilter implements ContainerRequestFilter {
     var headers = containerRequestContext.getHeaders();
     var token = headers.getFirst(HttpHeaders.AUTHORIZATION);
     if (token != null) {
-      var bearer = token.replace("Bearer ", "");
+      var bearer = token.replaceFirst("(?i)^Bearer ", "");
       claimsCache.loadCache(bearer, headers);
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/filters/ClaimsCacheTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/filters/ClaimsCacheTest.java
@@ -3,7 +3,7 @@ package org.broadinstitute.consent.http.filters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -81,14 +81,36 @@ class ClaimsCacheTest {
   }
 
   @Test
-  void testLoadCacheWithNullHeaderValueListThrows() {
-    // A null value list reaches the null branch in getFirst(), but Collectors.toMap
-    // does not support null values, so NPE is thrown before the entry is stored.
+  void testLoadCacheWithNullHeaderValueListOmitsKey() {
     Set<Map.Entry<String, List<String>>> entries = new HashSet<>();
     entries.add(new AbstractMap.SimpleEntry<>(ClaimsCache.OAUTH2_CLAIM_email, null));
     when(mockHeaders.entrySet()).thenReturn(entries);
 
-    assertThrows(
-        NullPointerException.class, () -> claimsCache.loadCache("test-token", mockHeaders));
+    claimsCache.loadCache("test-token", mockHeaders);
+
+    Map<String, String> cached = claimsCache.cache.getIfPresent("test-token");
+    assertNotNull(cached);
+    assertFalse(cached.containsKey(ClaimsCache.OAUTH2_CLAIM_email));
+  }
+
+  @Test
+  void testLoadCacheWithEmptyHeaderValueListOmitsKey() {
+    MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+    headers.put(ClaimsCache.OAUTH2_CLAIM_email, List.of());
+
+    claimsCache.loadCache("test-token", headers);
+
+    Map<String, String> cached = claimsCache.cache.getIfPresent("test-token");
+    assertNotNull(cached);
+    assertFalse(cached.containsKey(ClaimsCache.OAUTH2_CLAIM_email));
+  }
+
+  @Test
+  void testLoadCacheDoesNotThrowWhenHeadersThrow() {
+    when(mockHeaders.entrySet()).thenThrow(new RuntimeException("simulated failure"));
+
+    claimsCache.loadCache("test-token", mockHeaders);
+
+    assertNull(claimsCache.cache.getIfPresent("test-token"));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/filters/RequestHeaderCacheFilterTest.java
@@ -11,6 +11,8 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -29,9 +31,10 @@ class RequestHeaderCacheFilterTest {
     when(requestContext.getHeaders()).thenReturn(headers);
   }
 
-  @Test
-  void testFilterCallsLoadCacheWhenTokenPresent() throws Exception {
-    when(headers.getFirst(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer test-token");
+  @ParameterizedTest
+  @ValueSource(strings = {"Bearer test-token", "bearer test-token", "BEARER test-token"})
+  void testFilterStripsBeaererPrefixCaseInsensitively(String authHeader) throws Exception {
+    when(headers.getFirst(HttpHeaders.AUTHORIZATION)).thenReturn(authHeader);
 
     filter.filter(requestContext);
 


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3690](https://broadworkbench.atlassian.net/browse/DT-3690)

### Summary

ClaimsCache.java

- Race condition (check-then-put): Replaced the non-atomic getIfPresent + put pattern with cache.get(token, callable), which serialises loads per key under Guava's own lock. Two threads racing on the same new token now produce a single cache entry.

- NPE / auth bypass: The previous fallback stored "" for null or empty OAUTH2_CLAIM_* value lists. Collectors.toMap threw NullPointerException on null, and the "" sentinel would have bypassed the email == null guard in AuthorizationHelper. Both problems are fixed by filtering out null/empty-list entries before collecting — absent claims produce no map entry, so existing null-guards fire correctly.

- Unnecessary lock contention: Removed cache.cleanUp() from the insertion path. Guava performs expiry lazily during normal cache operations; calling cleanUp() on every write added unnecessary segment-level locking.

- Dead exception handler: Changed catch (ExecutionException _) to catch (Exception _). Guava re-throws RuntimeExceptions from the callable as UncheckedExecutionException (a RuntimeException subtype), which ExecutionException never intercepts. The original catch block was dead for all realistic failure paths; the intent — don't crash the request filter if the header map is malformed — now actually works.

RequestHeaderCacheFilter.java

- Case-sensitive Bearer stripping (RFC 7235): Replaced token.replace("Bearer ", "") with token.replaceFirst("(?i)^Bearer ", ""). OAuth2 clients that send bearer <token> (lowercase) were storing the full prefixed string as the cache key, causing a permanent cache miss for every request from those clients.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
