### PR TITLE
DT-3598: Mark dataset registration schema API as deprecated

### DIFF
--- a/src/main/resources/assets/paths/schemaDatasetRegistrationV1.yaml
+++ b/src/main/resources/assets/paths/schemaDatasetRegistrationV1.yaml
@@ -1,5 +1,6 @@
 get:
   summary: Dataset Registration Schema V1
+  deprecated: true
   description: Dataset Registration Schema V1
   operationId: schemasDatasetRegistrationV1Get
   tags:


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3598

### Summary
Small PR to deprecate the current `GET /schemas/dataset-registration/v1` endpoint.

Follow-on work will remove this once the [UI cleanup work](https://github.com/DataBiosphere/duos-ui/pull/3620) is complete.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
